### PR TITLE
Made the members binder non-generic

### DIFF
--- a/TryAtSoftware.Extensions.Reflection.Tests/MembersBinderExtensionsTests.cs
+++ b/TryAtSoftware.Extensions.Reflection.Tests/MembersBinderExtensionsTests.cs
@@ -22,11 +22,7 @@ public class MembersBinderExtensionsTests
     }
 
     [Fact]
-    public void GetRequiredMemberInfoShouldHandleInvalidMembersBinderParameter()
-    {
-        IMembersBinder<Person> membersBinder = null;
-        Assert.Throws<ArgumentNullException>(() => membersBinder.GetRequiredMemberInfo(nameof(Person.FirstName)));
-    }
+    public void GetRequiredMemberInfoShouldHandleInvalidMembersBinderParameter() => Assert.Throws<ArgumentNullException>(() => ((IMembersBinder) null).GetRequiredMemberInfo(nameof(Person.FirstName)));
 
     [Fact]
     public void GetRequiredMemberInfoShouldHandleInvalidMemberNameParameter()

--- a/TryAtSoftware.Extensions.Reflection.Tests/MembersBinderTests.cs
+++ b/TryAtSoftware.Extensions.Reflection.Tests/MembersBinderTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace TryAtSoftware.Extensions.Reflection.Tests;
 
+using System;
 using System.Reflection;
 using TryAtSoftware.Extensions.Reflection.Tests.Types;
 using Xunit;
@@ -7,7 +8,10 @@ using Xunit;
 public class MembersBinderTests
 {
     private const BindingFlags DefaultBindingFlags = BindingFlags.Public | BindingFlags.Instance;
-    
+
+    [Fact]
+    public void TheNonGenericMembersBinderShouldRequireProvidedType() => Assert.Throws<ArgumentNullException>(() => new MembersBinder(null!, MemberIsValid, DefaultBindingFlags));
+
     [Fact]
     public void MemberBinderShouldBeInitializedCorrectlyWithDifferentKeySelector()
     {

--- a/TryAtSoftware.Extensions.Reflection/Interfaces/IMembersBinder.cs
+++ b/TryAtSoftware.Extensions.Reflection/Interfaces/IMembersBinder.cs
@@ -1,11 +1,16 @@
 ﻿namespace TryAtSoftware.Extensions.Reflection.Interfaces;
 
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 using JetBrains.Annotations;
 
-public interface IMembersBinder<[UsedImplicitly] TEntity>
+public interface IMembersBinder
 {
-    [NotNull]
-    IReadOnlyDictionary<string, MemberInfo> MemberInfos { get; }
+    [NotNull] Type Type { get; }
+    [NotNull] IReadOnlyDictionary<string, MemberInfo> MemberInfos { get; }
+}
+
+public interface IMembersBinder<[UsedImplicitly] TEntity> : IMembersBinder
+{
 }

--- a/TryAtSoftware.Extensions.Reflection/Interfaces/IMembersBinder.cs
+++ b/TryAtSoftware.Extensions.Reflection/Interfaces/IMembersBinder.cs
@@ -10,7 +10,3 @@ public interface IMembersBinder
     [NotNull] Type Type { get; }
     [NotNull] IReadOnlyDictionary<string, MemberInfo> MemberInfos { get; }
 }
-
-public interface IMembersBinder<[UsedImplicitly] TEntity> : IMembersBinder
-{
-}

--- a/TryAtSoftware.Extensions.Reflection/MembersBinder.cs
+++ b/TryAtSoftware.Extensions.Reflection/MembersBinder.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Linq.Expressions;
 using System.Reflection;
 using JetBrains.Annotations;
 using TryAtSoftware.Extensions.Collections;
@@ -51,7 +50,7 @@ public class MembersBinder : IMembersBinder
     }
 }
 
-public class MembersBinder<TEntity> : MembersBinder, IMembersBinder<TEntity>
+public class MembersBinder<TEntity> : MembersBinder
 {
     public MembersBinder([CanBeNull] Func<MemberInfo, bool> isValid, BindingFlags bindingFlags)
         : this(isValid, keySelector: null, bindingFlags)

--- a/TryAtSoftware.Extensions.Reflection/MembersBinder.cs
+++ b/TryAtSoftware.Extensions.Reflection/MembersBinder.cs
@@ -3,24 +3,30 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq.Expressions;
 using System.Reflection;
 using JetBrains.Annotations;
 using TryAtSoftware.Extensions.Collections;
 using TryAtSoftware.Extensions.Reflection.Interfaces;
 
-public class MembersBinder<TEntity> : IMembersBinder<TEntity>
+public class MembersBinder : IMembersBinder
 {
-    public MembersBinder([CanBeNull] Func<MemberInfo, bool> isValid, BindingFlags bindingFlags)
-        : this(isValid, keySelector: null, bindingFlags)
+    public MembersBinder([NotNull] Type type, [CanBeNull] Func<MemberInfo, bool> isValid, BindingFlags bindingFlags)
+        : this(type, isValid, keySelector: null, bindingFlags)
     {
     }
     
-    public MembersBinder([CanBeNull] Func<MemberInfo, bool> isValid, [CanBeNull] Func<MemberInfo, string> keySelector, BindingFlags bindingFlags)
+    public MembersBinder([NotNull] Type type, [CanBeNull] Func<MemberInfo, bool> isValid, [CanBeNull] Func<MemberInfo, string> keySelector, BindingFlags bindingFlags)
     {
-        var members = GetMembers(typeof(TEntity), isValid, bindingFlags, keySelector);
+        this.Type = type ?? throw new ArgumentNullException(nameof(type));
+        var members = GetMembers(type, isValid, bindingFlags, keySelector);
         this.MemberInfos = new ReadOnlyDictionary<string, MemberInfo>(members);
     }
 
+    /// <inheritdoc />
+    public Type Type { get; }
+
+    /// <inheritdoc />
     public IReadOnlyDictionary<string, MemberInfo> MemberInfos { get; }
 
     private static Dictionary<string, MemberInfo> GetMembers([NotNull] IReflect type, [CanBeNull] Func<MemberInfo, bool> isValid, BindingFlags bindingFlags, [CanBeNull] Func<MemberInfo, string> keySelector)
@@ -42,5 +48,18 @@ public class MembersBinder<TEntity> : IMembersBinder<TEntity>
         }
 
         return membersDict;
+    }
+}
+
+public class MembersBinder<TEntity> : MembersBinder, IMembersBinder<TEntity>
+{
+    public MembersBinder([CanBeNull] Func<MemberInfo, bool> isValid, BindingFlags bindingFlags)
+        : this(isValid, keySelector: null, bindingFlags)
+    {
+    }
+    
+    public MembersBinder([CanBeNull] Func<MemberInfo, bool> isValid, [CanBeNull] Func<MemberInfo, string> keySelector, BindingFlags bindingFlags)
+        : base(typeof(TEntity), isValid, keySelector, bindingFlags)
+    {
     }
 }

--- a/TryAtSoftware.Extensions.Reflection/MembersBinderExtensions.cs
+++ b/TryAtSoftware.Extensions.Reflection/MembersBinderExtensions.cs
@@ -6,15 +6,13 @@ using TryAtSoftware.Extensions.Reflection.Interfaces;
 
 public static class MembersBinderExtensions
 {
-    public static MemberInfo GetRequiredMemberInfo<T>(this IMembersBinder<T> membersBinder, string name)
+    public static MemberInfo GetRequiredMemberInfo(this IMembersBinder membersBinder, string name)
     {
-        if (membersBinder is null)
-            throw new ArgumentNullException(nameof(membersBinder));
-        if (string.IsNullOrEmpty(name))
-            throw new ArgumentNullException(nameof(name));
+        if (membersBinder is null) throw new ArgumentNullException(nameof(membersBinder));
+        if (string.IsNullOrEmpty(name)) throw new ArgumentNullException(nameof(name));
 
         if (!membersBinder.MemberInfos.TryGetValue(name, out var memberInfo))
-            throw new InvalidOperationException($"Member {name} not found in {typeof(T).Name}");
+            throw new InvalidOperationException($"Member {name} not found in {membersBinder.Type.Name}");
 
         return memberInfo;
     }


### PR DESCRIPTION
This PR introduces a breaking change - the `IMembersBinder<T>` interface is completely removed.