### PR TITLE
Added support for discovering members of extended interfaces

### DIFF
--- a/TryAtSoftware.Extensions.Reflection.Tests/ExpressionsExtensionsTests.cs
+++ b/TryAtSoftware.Extensions.Reflection.Tests/ExpressionsExtensionsTests.cs
@@ -10,8 +10,6 @@ using TryAtSoftware.Extensions.Reflection.Tests.Models.Specialized;
 using TryAtSoftware.Extensions.Reflection.Tests.Randomization;
 using TryAtSoftware.Randomizer.Core.Helpers;
 using Xunit;
-using static System.Net.Mime.MediaTypeNames;
-using static System.Runtime.InteropServices.JavaScript.JSType;
 
 public class ExpressionsExtensionsTests
 {
@@ -31,13 +29,11 @@ public class ExpressionsExtensionsTests
         Assert.Throws<InvalidOperationException>(() => expression.GetMemberInfo());
     }
 
-    [Fact]
-    public void PropertyAccessorShouldBeSuccessfullyConstructed()
+    [Theory]
+    [MemberData(nameof(GeneratePersonInstances))]
+    public void PropertyAccessorShouldBeSuccessfullyConstructed(Person person)
     {
         var firstNameAccessor = GetCompiledPropertyAccessor<Person, string>(nameof(Person.FirstName));
-
-        var personRandomizer = new PersonRandomizer();
-        var person = personRandomizer.PrepareRandomValue();
 
         var firstName = firstNameAccessor(person);
         Assert.Equal(person.FirstName, firstName);
@@ -88,12 +84,12 @@ public class ExpressionsExtensionsTests
         Assert.Throws<InvalidOperationException>(() => inaccessiblePropertySetter.ConstructPropertyAccessor<ModelWithInaccessibleProperty, string>());
     }
 
-    [Fact]
-    public void PropertySetterShouldBeConstructedSuccessfully()
+    [Theory]
+    [MemberData(nameof(GeneratePersonInstances))]
+    public void PropertySetterShouldBeConstructedSuccessfully(Person person)
     {
         var firstNameSetter = GetCompiledPropertySetter<Person, string>(nameof(Person.FirstName));
 
-        var person = new Person();
         var randomString = RandomizationHelper.GetRandomString();
 
         firstNameSetter(person, randomString);
@@ -211,6 +207,15 @@ public class ExpressionsExtensionsTests
 
     [Fact]
     public void ExceptionShouldBeThrownIfNullIsPassedToTheConstructObjectInitializerMethod() => Assert.Throws<ArgumentNullException>(() => ((ConstructorInfo)null!).ConstructObjectInitializer<ModelWithConstructors>());
+
+    public static IEnumerable<object[]> GeneratePersonInstances()
+    {
+        var personRandomizer = new PersonRandomizer();
+        var studentRandomizer = new StudentRandomizer();
+
+        yield return new object[] { personRandomizer.PrepareRandomValue() };
+        yield return new object[] { studentRandomizer.PrepareRandomValue() };
+    }
 
     public static IEnumerable<object?[]> GenerateObjectInitializationParameters()
     {

--- a/TryAtSoftware.Extensions.Reflection.Tests/MembersBinderTests.cs
+++ b/TryAtSoftware.Extensions.Reflection.Tests/MembersBinderTests.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Reflection;
 using TryAtSoftware.Extensions.Reflection.Tests.Models;
+using TryAtSoftware.Extensions.Reflection.Tests.Models.Interfaces;
 using Xunit;
 
 public class MembersBinderTests
@@ -18,27 +19,21 @@ public class MembersBinderTests
         var personMembersBinder = new MembersBinder<Person>(MemberIsValid, KeySelector, DefaultBindingFlags);
         Assert.NotNull(personMembersBinder.MemberInfos);
 
+        Assert.NotNull(personMembersBinder.MemberInfos);
         Assert.Equal(4, personMembersBinder.MemberInfos.Count);
+        Assert.Equal(typeof(Person), personMembersBinder.Type);
 
         var firstNameKey = ChangeName(nameof(Person.FirstName));
-        Assert.True(personMembersBinder.MemberInfos.TryGetValue(firstNameKey, out var firstNameMemberInfo));
-        Assert.NotNull(firstNameMemberInfo);
-        firstNameMemberInfo.AssertSameMember(typeof(Person), nameof(Person.FirstName));
+        personMembersBinder.AssertMemberExists(typeof(Person), firstNameKey, nameof(Person.FirstName));
 
         var middleNameKey = ChangeName(nameof(Person.MiddleName));
-        Assert.True(personMembersBinder.MemberInfos.TryGetValue(middleNameKey, out var middleNameMemberInfo));
-        Assert.NotNull(middleNameMemberInfo);
-        middleNameMemberInfo.AssertSameMember(typeof(Person), nameof(Person.MiddleName));
+        personMembersBinder.AssertMemberExists(typeof(Person), middleNameKey, nameof(Person.MiddleName));
 
         var lastNameKey = ChangeName(nameof(Person.LastName));
-        Assert.True(personMembersBinder.MemberInfos.TryGetValue(lastNameKey, out var lastNameMemberInfo));
-        Assert.NotNull(lastNameMemberInfo);
-        lastNameMemberInfo.AssertSameMember(typeof(Person), nameof(Person.LastName));
+        personMembersBinder.AssertMemberExists(typeof(Person), lastNameKey, nameof(Person.LastName));
 
         var ageKey = ChangeName(nameof(Person.Age));
-        Assert.True(personMembersBinder.MemberInfos.TryGetValue(ageKey, out var ageMemberInfo));
-        Assert.NotNull(ageMemberInfo);
-        ageMemberInfo.AssertSameMember(typeof(Person), nameof(Person.Age));
+        personMembersBinder.AssertMemberExists(typeof(Person), ageKey, nameof(Person.Age));
 
         string KeySelector(MemberInfo member) => ChangeName(member.Name);
         string ChangeName(string memberName) => $"M_{memberName}";
@@ -47,57 +42,48 @@ public class MembersBinderTests
     [Fact]
     public void MemberBinderShouldBeInitializedCorrectly()
     {
-        var personMembersBinder = new MembersBinder<Person>(MemberIsValid, BindingFlags.Public | BindingFlags.Instance);
+        var personMembersBinder = new MembersBinder<Person>(MemberIsValid, DefaultBindingFlags);
 
         Assert.NotNull(personMembersBinder.MemberInfos);
-
         Assert.Equal(4, personMembersBinder.MemberInfos.Count);
+        Assert.Equal(typeof(Person), personMembersBinder.Type);
 
-        Assert.True(personMembersBinder.MemberInfos.TryGetValue(nameof(Person.FirstName), out var firstNameMemberInfo));
-        Assert.NotNull(firstNameMemberInfo);
-        firstNameMemberInfo.AssertSameMember(typeof(Person), nameof(Person.FirstName));
-
-        Assert.True(personMembersBinder.MemberInfos.TryGetValue(nameof(Person.MiddleName), out var middleNameMemberInfo));
-        Assert.NotNull(middleNameMemberInfo);
-        middleNameMemberInfo.AssertSameMember(typeof(Person), nameof(Person.MiddleName));
-
-        Assert.True(personMembersBinder.MemberInfos.TryGetValue(nameof(Person.LastName), out var lastNameMemberInfo));
-        Assert.NotNull(lastNameMemberInfo);
-        lastNameMemberInfo.AssertSameMember(typeof(Person), nameof(Person.LastName));
-
-        Assert.True(personMembersBinder.MemberInfos.TryGetValue(nameof(Person.Age), out var ageMemberInfo));
-        Assert.NotNull(ageMemberInfo);
-        ageMemberInfo.AssertSameMember(typeof(Person), nameof(Person.Age));
+        personMembersBinder.AssertMemberExists(typeof(Person), nameof(Person.FirstName));
+        personMembersBinder.AssertMemberExists(typeof(Person), nameof(Person.MiddleName));
+        personMembersBinder.AssertMemberExists(typeof(Person), nameof(Person.LastName));
+        personMembersBinder.AssertMemberExists(typeof(Person), nameof(Person.Age));
     }
 
     [Fact]
     public void MemberBinderShouldBeInitializedCorrectlyForDerivedTypes()
     {
-        var personMembersBinder = new MembersBinder<Student>(MemberIsValid, DefaultBindingFlags | BindingFlags.FlattenHierarchy);
+        var personMembersBinder = new MembersBinder<Student>(MemberIsValid, DefaultBindingFlags);
 
         Assert.NotNull(personMembersBinder.MemberInfos);
-
         Assert.Equal(5, personMembersBinder.MemberInfos.Count);
+        Assert.Equal(typeof(Student), personMembersBinder.Type);
 
-        Assert.True(personMembersBinder.MemberInfos.TryGetValue(nameof(Person.FirstName), out var firstNameMemberInfo));
-        Assert.NotNull(firstNameMemberInfo);
-        firstNameMemberInfo.AssertSameMember(typeof(Person), nameof(Person.FirstName));
+        personMembersBinder.AssertMemberExists(typeof(Person), nameof(Person.FirstName));
+        personMembersBinder.AssertMemberExists(typeof(Person), nameof(Person.MiddleName));
+        personMembersBinder.AssertMemberExists(typeof(Person), nameof(Person.LastName));
+        personMembersBinder.AssertMemberExists(typeof(Person), nameof(Person.Age));
+        personMembersBinder.AssertMemberExists(typeof(Student), nameof(Student.School));
+    }
 
-        Assert.True(personMembersBinder.MemberInfos.TryGetValue(nameof(Person.MiddleName), out var middleNameMemberInfo));
-        Assert.NotNull(middleNameMemberInfo);
-        middleNameMemberInfo.AssertSameMember(typeof(Person), nameof(Person.MiddleName));
-
-        Assert.True(personMembersBinder.MemberInfos.TryGetValue(nameof(Person.LastName), out var lastNameMemberInfo));
-        Assert.NotNull(lastNameMemberInfo);
-        lastNameMemberInfo.AssertSameMember(typeof(Person), nameof(Person.LastName));
-
-        Assert.True(personMembersBinder.MemberInfos.TryGetValue(nameof(Person.Age), out var ageMemberInfo));
-        Assert.NotNull(ageMemberInfo);
-        ageMemberInfo.AssertSameMember(typeof(Person), nameof(Person.Age));
-
-        Assert.True(personMembersBinder.MemberInfos.TryGetValue(nameof(Student.School), out var schoolMemberInfo));
-        Assert.NotNull(schoolMemberInfo);
-        schoolMemberInfo.AssertSameMember(typeof(Student), nameof(Student.School));
+    [Fact]
+    public void MembersBinderShouldIncludedMembersFromExtendedInterfaces()
+    {
+        var trackableMembersBinder = new MembersBinder<ITrackable>(memberInfo => memberInfo.MemberType == MemberTypes.Property, DefaultBindingFlags);
+        
+        Assert.NotNull(trackableMembersBinder.MemberInfos);
+        Assert.Equal(5, trackableMembersBinder.MemberInfos.Count);
+        Assert.Equal(typeof(ITrackable), trackableMembersBinder.Type);
+        
+        trackableMembersBinder.AssertMemberExists(typeof(IIdentifiable), nameof(IIdentifiable.Id));
+        trackableMembersBinder.AssertMemberExists(typeof(ITrackable), nameof(ITrackable.CreatedBy));
+        trackableMembersBinder.AssertMemberExists(typeof(ITrackable), nameof(ITrackable.CreatedAt));
+        trackableMembersBinder.AssertMemberExists(typeof(ITrackable), nameof(ITrackable.LastModifiedBy));
+        trackableMembersBinder.AssertMemberExists(typeof(ITrackable), nameof(ITrackable.LastModifiedAt));
     }
 
     private static bool MemberIsValid(MemberInfo memberInfo) => memberInfo is PropertyInfo { CanWrite: true };

--- a/TryAtSoftware.Extensions.Reflection.Tests/Models/Interfaces/IIdentifiable.cs
+++ b/TryAtSoftware.Extensions.Reflection.Tests/Models/Interfaces/IIdentifiable.cs
@@ -1,0 +1,8 @@
+﻿namespace TryAtSoftware.Extensions.Reflection.Tests.Models.Interfaces;
+
+using System;
+
+public interface IIdentifiable
+{
+    Guid Id { get; }
+}

--- a/TryAtSoftware.Extensions.Reflection.Tests/Models/Interfaces/ITrackable.cs
+++ b/TryAtSoftware.Extensions.Reflection.Tests/Models/Interfaces/ITrackable.cs
@@ -1,0 +1,12 @@
+﻿namespace TryAtSoftware.Extensions.Reflection.Tests.Models.Interfaces;
+
+using System;
+
+public interface ITrackable : IIdentifiable
+{
+    Guid CreatedBy { get; }
+    DateTimeOffset CreatedAt { get; }
+    
+    Guid LastModifiedBy { get; }
+    DateTimeOffset LastModifiedAt { get; }
+}

--- a/TryAtSoftware.Extensions.Reflection.Tests/Randomization/StudentRandomizer.cs
+++ b/TryAtSoftware.Extensions.Reflection.Tests/Randomization/StudentRandomizer.cs
@@ -1,0 +1,19 @@
+﻿namespace TryAtSoftware.Extensions.Reflection.Tests.Randomization;
+
+using TryAtSoftware.Extensions.Reflection.Tests.Models;
+using TryAtSoftware.Randomizer.Core;
+using TryAtSoftware.Randomizer.Core.Primitives;
+
+public class StudentRandomizer : ComplexRandomizer<Student>
+{
+    public StudentRandomizer()
+        : base(new GeneralInstanceBuilder<Student>())
+    {
+        this.AddRandomizationRule(x => x.FirstName, new StringRandomizer());
+        this.AddRandomizationRule(x => x.MiddleName, new StringRandomizer());
+        this.AddRandomizationRule(x => x.LastName, new StringRandomizer());
+        this.AddRandomizationRule(x => x.Age, new NumberRandomizer());
+
+        this.AddRandomizationRule(x => x.School, new StringRandomizer());
+    }
+}

--- a/TryAtSoftware.Extensions.Reflection.Tests/TestsHelper.cs
+++ b/TryAtSoftware.Extensions.Reflection.Tests/TestsHelper.cs
@@ -2,13 +2,31 @@
 
 using System;
 using System.Reflection;
+using TryAtSoftware.Extensions.Reflection.Interfaces;
 using Xunit;
 
 public static class TestsHelper
 {
+    public static void AssertMemberExists(this IMembersBinder membersBinder, Type declaringType, string memberName) => membersBinder.AssertMemberExists(declaringType, memberName, memberName);
+
+    public static void AssertMemberExists(this IMembersBinder membersBinder, Type declaringType, string memberKey, string memberName)
+    {
+        Assert.NotNull(membersBinder);
+        Assert.NotNull(declaringType);
+        Assert.False(string.IsNullOrWhiteSpace(memberKey));
+        Assert.False(string.IsNullOrWhiteSpace(memberName));
+
+        Assert.True(membersBinder.MemberInfos.TryGetValue(memberKey, out var memberInfo));
+        Assert.NotNull(memberInfo);
+        memberInfo.AssertSameMember(declaringType, memberName);
+    }
+    
     public static void AssertSameMember(this MemberInfo memberInfo, Type declaringType, string memberName)
     {
         Assert.NotNull(memberInfo);
+        Assert.NotNull(declaringType);
+        Assert.False(string.IsNullOrWhiteSpace(memberName));
+
         Assert.Equal(memberName, memberInfo.Name);
         Assert.Equal(declaringType, memberInfo.DeclaringType);
     }

--- a/TryAtSoftware.Extensions.Reflection/ExpressionsExtensions.cs
+++ b/TryAtSoftware.Extensions.Reflection/ExpressionsExtensions.cs
@@ -1,7 +1,6 @@
 namespace TryAtSoftware.Extensions.Reflection;
 
 using System;
-using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Reflection;
 
@@ -88,7 +87,7 @@ public static class ExpressionsExtensions
     /// <summary>
     /// Use this method in order to construct an <see cref="Expression"/> for instantiation an object of type <typeparamref name="T"/> using the requested <paramref name="constructorInfo"/>.
     /// </summary>
-    /// <param name="propertyInfo">The <see cref="ConstructorInfo"/> describing the constructor that should be used during the instantiation process.</param>
+    /// <param name="constructorInfo">The <see cref="ConstructorInfo"/> describing the constructor that should be used during the instantiation process.</param>
     /// <typeparam name="T">The type of object to be instantiated (should be equal to the reflected type of the extended <paramref name="constructorInfo"/>).</typeparam>
     /// <returns>Returns a subsequently built expression for constructing a new instance of type <typeparamref name="T"/>.</returns>
     /// <exception cref="ArgumentNullException">Thrown if the provided <paramref name="constructorInfo"/> is null.</exception>
@@ -98,6 +97,8 @@ public static class ExpressionsExtensions
     {
         if (constructorInfo is null) throw new ArgumentNullException(nameof(constructorInfo));
         ValidateCorrectReflectedType(constructorInfo, typeof(T));
+
+        if (constructorInfo.DeclaringType is null) throw new InvalidOperationException("The `DeclaringType` property for the constructor was null.");
         if (constructorInfo.DeclaringType.IsAbstract) throw new InvalidOperationException("This is a constructor of an abstract class.");
 
         var argumentsParameter = Expression.Parameter(typeof(object?[]));
@@ -118,6 +119,8 @@ public static class ExpressionsExtensions
 
     private static void ValidateCorrectReflectedType(MemberInfo memberInfo, Type operativeType)
     {
-        if (memberInfo.ReflectedType != operativeType) throw new InvalidOperationException($"The provided member was obtained from a different type. Member name: {memberInfo.Name}, T: {TypeNames.Get(operativeType)}, Reflected type: {TypeNames.Get(memberInfo.ReflectedType)}");
+        var reflectedType = memberInfo.ReflectedType;
+        if (reflectedType is null) throw new InvalidOperationException($"The `ReflectedType` property for the member {memberInfo.Name} was null.");
+        if (!reflectedType.IsAssignableFrom(operativeType)) throw new InvalidOperationException($"The provided member was obtained from a different type. Member name: {memberInfo.Name}, T: {TypeNames.Get(operativeType)}, Reflected type: {TypeNames.Get(reflectedType)}");
     }
 }


### PR DESCRIPTION
It is known that calling `.GetMembers()` on an interface type will not include members from other interfaces the one extends.
This dramatically affects the `IMembersBinder` and respectively all components that depend on its content.