### PR TITLE
Object initialization - parameters count validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,6 +465,11 @@ This is an extension method that should construct an expression for instantiatin
 Usually, it is a good practice to minimize the reflection calls in code. One way of achieving this is throughout expressions (that are constructed and compiled only once for the lifetime of a program).
 This expression method can be easily used with the `IMembersBinder` we described in the previous chapter.
 
+This methods accept one optional parameter called `includeParametersCountValidation`. It indicates whether or not the subsequently constructed expression should include a check to validate the correct count of provided values.
+
+An expression constructed by this extension method can be compiled to a function that accepts an array of values that correspond to the parameters of the extended `ConstructorInfo` instance.
+If any of the parameters is optional and its default value should be used, the corresponding element (from the provided array) must be `null`.
+
 Example:
 
 ```C#

--- a/TryAtSoftware.Extensions.Reflection.Benchmark/ModelInstantiating.cs
+++ b/TryAtSoftware.Extensions.Reflection.Benchmark/ModelInstantiating.cs
@@ -6,25 +6,29 @@ using BenchmarkDotNet.Attributes;
 using TryAtSoftware.Extensions.Reflection.Benchmark.Models;
 
 /*
-16/03/2023, TryAtSoftware.Extensions.Reflection v1.1.1-alpha.2
-|                                                        Method |           Mean |         Error |        StdDev |         Median |
-|-------------------------------------------------------------- |---------------:|--------------:|--------------:|---------------:|
-|                InstantiateModelUsingReflection_ZeroParameters |       7.879 ns |     0.1447 ns |     0.2457 ns |       7.785 ns |
-|     InstantiateModelUsingConstructorInvocation_ZeroParameters |      11.843 ns |     0.2483 ns |     0.2550 ns |      11.782 ns |
-|                InstantiateModelUsingExpression_ZeroParameters |       4.364 ns |     0.1107 ns |     0.0925 ns |       4.389 ns |
-|                  InstantiateModelUsingReflection_OneParameter |     282.762 ns |     2.6890 ns |     2.5153 ns |     281.976 ns |
-|       InstantiateModelUsingConstructorInvocation_OneParameter |      31.854 ns |     0.2600 ns |     0.2432 ns |      31.803 ns |
-|                  InstantiateModelUsingExpression_OneParameter |      10.366 ns |     0.1512 ns |     0.1680 ns |      10.370 ns |
-|                 InstantiateModelUsingReflection_TwoParameters |     363.171 ns |     4.3010 ns |     3.5915 ns |     362.873 ns |
-|      InstantiateModelUsingConstructorInvocation_TwoParameters |      42.800 ns |     0.7584 ns |     0.6723 ns |      42.575 ns |
-|                 InstantiateModelUsingExpression_TwoParameters |      12.902 ns |     0.1436 ns |     0.1596 ns |      12.950 ns |
-|            InstantiateModelUsingReflection_OptionalParameters |     480.628 ns |     9.5506 ns |    17.7026 ns |     474.349 ns |
-| InstantiateModelUsingConstructorInvocation_OptionalParameters |     130.349 ns |     0.8773 ns |     0.8206 ns |     130.368 ns |
-|            InstantiateModelUsingExpression_OptionalParameters |      19.324 ns |     0.3094 ns |     0.2894 ns |      19.382 ns |
-|            CompileModelInstantiatingExpression_ZeroParameters |  47,160.173 ns |   873.2294 ns | 1,005.6123 ns |  46,780.139 ns |
-|              CompileModelInstantiatingExpression_OneParameter | 113,940.085 ns | 2,175.4359 ns | 4,344.5806 ns | 111,696.851 ns |
-|             CompileModelInstantiatingExpression_TwoParameters | 161,824.582 ns |   859.5220 ns |   803.9974 ns | 161,836.035 ns |
-|        CompileModelInstantiatingExpression_OptionalParameters | 166,530.435 ns | 1,653.4656 ns | 1,380.7186 ns | 167,216.040 ns |
+Examined on 20/03/2023:
+|                                                                Method |           Mean |         Error |        StdDev |
+|---------------------------------------------------------------------- |---------------:|--------------:|--------------:|
+|                        InstantiateModelUsingReflection_ZeroParameters |       8.396 ns |     0.0641 ns |     0.0599 ns |
+|             InstantiateModelUsingConstructorInvocation_ZeroParameters |      12.318 ns |     0.1068 ns |     0.0999 ns |
+|                        InstantiateModelUsingExpression_ZeroParameters |       4.960 ns |     0.1138 ns |     0.1310 ns |
+|                          InstantiateModelUsingReflection_OneParameter |     275.653 ns |     2.4048 ns |     1.8775 ns |
+|               InstantiateModelUsingConstructorInvocation_OneParameter |      30.740 ns |     0.1956 ns |     0.1633 ns |
+|                          InstantiateModelUsingExpression_OneParameter |      10.737 ns |     0.2087 ns |     0.1743 ns |
+|                         InstantiateModelUsingReflection_TwoParameters |     349.846 ns |     2.0746 ns |     1.8391 ns |
+|              InstantiateModelUsingConstructorInvocation_TwoParameters |      42.796 ns |     0.3557 ns |     0.2970 ns |
+|                         InstantiateModelUsingExpression_TwoParameters |      13.665 ns |     0.0696 ns |     0.0774 ns |
+|                    InstantiateModelUsingReflection_OptionalParameters |     445.106 ns |     6.2165 ns |     5.5108 ns |
+|         InstantiateModelUsingConstructorInvocation_OptionalParameters |     148.657 ns |     1.3886 ns |     1.2310 ns |
+|                    InstantiateModelUsingExpression_OptionalParameters |      17.780 ns |     0.2495 ns |     0.3415 ns |
+|                    CompileModelInstantiatingExpression_ZeroParameters |  46,628.233 ns |   924.4086 ns | 1,713.4506 ns |
+|     CompileModelInstantiatingExpression_ZeroParameters_WithValidation |  92,992.725 ns |   457.8785 ns |   405.8974 ns |
+|                      CompileModelInstantiatingExpression_OneParameter | 109,652.003 ns |   714.1525 ns |   633.0775 ns |
+|       CompileModelInstantiatingExpression_OneParameter_WithValidation | 160,086.966 ns | 3,105.9800 ns | 3,050.4877 ns |
+|                     CompileModelInstantiatingExpression_TwoParameters | 157,889.117 ns | 1,071.3123 ns |   949.6904 ns |
+|      CompileModelInstantiatingExpression_TwoParameters_WithValidation | 200,620.907 ns |   836.0908 ns |   741.1727 ns |
+|                CompileModelInstantiatingExpression_OptionalParameters | 163,244.454 ns | 1,572.9164 ns | 1,228.0297 ns |
+| CompileModelInstantiatingExpression_OptionalParameters_WithValidation | 211,173.854 ns | 1,225.5750 ns | 1,086.4404 ns |
  */
 public class ModelInstantiating
 {
@@ -58,7 +62,7 @@ public class ModelInstantiating
 
     [Benchmark]
     public void InstantiateModelUsingReflection_ZeroParameters() => _ = Activator.CreateInstance(this._type);
-
+    
     [Benchmark]
     public void InstantiateModelUsingConstructorInvocation_ZeroParameters() => _ = this._emptyConstructorInfo.Invoke(Array.Empty<object?>());
     
@@ -70,7 +74,7 @@ public class ModelInstantiating
     
     [Benchmark]
     public void InstantiateModelUsingConstructorInvocation_OneParameter() => _ = this._oneParameterConstructorInfo.Invoke(new object[] { "value1" });
-
+    
     [Benchmark]
     public void InstantiateModelUsingExpression_OneParameter() => _ = this._compiledExpressionOneParameter(new object?[] { "value1" });
     
@@ -79,16 +83,13 @@ public class ModelInstantiating
     
     [Benchmark]
     public void InstantiateModelUsingConstructorInvocation_TwoParameters() => _ = this._twoParametersConstructorInfo.Invoke(new object[] { "value1", "value2" });
-
+    
     [Benchmark]
     public void InstantiateModelUsingExpression_TwoParameters() => _ = this._compiledExpressionTwoParameters(new object?[] { "value1", "value2" });
     
     [Benchmark]
-    public void InstantiateModelUsingReflection_ThreeParameters() => _ = Activator.CreateInstance(this._type, "value1", "value2", "value3");
-    
-    [Benchmark]
     public void InstantiateModelUsingReflection_OptionalParameters() => _ = Activator.CreateInstance(this._type, BindingFlags.OptionalParamBinding, null, new object?[] { 25 }, CultureInfo.InvariantCulture);
-
+    
     [Benchmark]
     public void InstantiateModelUsingConstructorInvocation_OptionalParameters() => _ = this._optionalParametersConstructorInfo.Invoke(new[] { 25, Type.Missing });
     
@@ -99,11 +100,23 @@ public class ModelInstantiating
     public void CompileModelInstantiatingExpression_ZeroParameters() => _ = this._emptyConstructorInfo.ConstructObjectInitializer<ModelWithConstructors>().Compile();
     
     [Benchmark]
+    public void CompileModelInstantiatingExpression_ZeroParameters_WithValidation() => _ = this._emptyConstructorInfo.ConstructObjectInitializer<ModelWithConstructors>(includeParametersCountValidation: true).Compile();
+    
+    [Benchmark]
     public void CompileModelInstantiatingExpression_OneParameter() => _ = this._oneParameterConstructorInfo.ConstructObjectInitializer<ModelWithConstructors>().Compile();
+
+    [Benchmark]
+    public void CompileModelInstantiatingExpression_OneParameter_WithValidation() => _ = this._oneParameterConstructorInfo.ConstructObjectInitializer<ModelWithConstructors>(includeParametersCountValidation: true).Compile();
     
     [Benchmark]
     public void CompileModelInstantiatingExpression_TwoParameters() => _ = this._twoParametersConstructorInfo.ConstructObjectInitializer<ModelWithConstructors>().Compile();
+
+    [Benchmark]
+    public void CompileModelInstantiatingExpression_TwoParameters_WithValidation() => _ = this._twoParametersConstructorInfo.ConstructObjectInitializer<ModelWithConstructors>(includeParametersCountValidation: true).Compile();
     
     [Benchmark]
     public void CompileModelInstantiatingExpression_OptionalParameters() => _ = this._optionalParametersConstructorInfo.ConstructObjectInitializer<ModelWithConstructors>().Compile();
+
+    [Benchmark]
+    public void CompileModelInstantiatingExpression_OptionalParameters_WithValidation() => _ = this._optionalParametersConstructorInfo.ConstructObjectInitializer<ModelWithConstructors>(includeParametersCountValidation: true).Compile();
 }

--- a/TryAtSoftware.Extensions.Reflection.Benchmark/ValueRetrieving.cs
+++ b/TryAtSoftware.Extensions.Reflection.Benchmark/ValueRetrieving.cs
@@ -5,7 +5,7 @@ using BenchmarkDotNet.Attributes;
 using TryAtSoftware.Extensions.Reflection.Benchmark.Models;
 
 /*
-16/03/2023, TryAtSoftware.Extensions.Reflection v1.1.1-alpha.2
+Examined on 16/03/2023:
 |                               Method |          Mean |       Error |      StdDev |
 |------------------------------------- |--------------:|------------:|------------:|
 | RetrievePropertyValueUsingReflection |     13.777 ns |   0.1390 ns |   0.1301 ns |

--- a/TryAtSoftware.Extensions.Reflection.Benchmark/ValueSetting.cs
+++ b/TryAtSoftware.Extensions.Reflection.Benchmark/ValueSetting.cs
@@ -5,7 +5,7 @@ using BenchmarkDotNet.Attributes;
 using TryAtSoftware.Extensions.Reflection.Benchmark.Models;
 
 /*
-16/03/2023, TryAtSoftware.Extensions.Reflection v1.1.1-alpha.2
+Examined on 16/03/2023:
 |                          Method |           Mean |       Error |      StdDev |
 |-------------------------------- |---------------:|------------:|------------:|
 | SetPropertyValueUsingReflection |     31.6062 ns |   0.3097 ns |   0.2586 ns |

--- a/TryAtSoftware.Extensions.Reflection.Tests/ExpressionsExtensionsTests.cs
+++ b/TryAtSoftware.Extensions.Reflection.Tests/ExpressionsExtensionsTests.cs
@@ -195,7 +195,7 @@ public class ExpressionsExtensionsTests
         var constructor = typeof(ModelWithConstructors).GetConstructor(new[] { typeof(string), typeof(int), typeof(char) });
         Assert.NotNull(constructor);
         
-        var newInstanceInitializerExpression = constructor.ConstructObjectInitializer<ModelWithConstructors>();
+        var newInstanceInitializerExpression = constructor.ConstructObjectInitializer<ModelWithConstructors>(includeParametersCountValidation: true);
         var newInstanceInitializer = newInstanceInitializerExpression.Compile();
 
         Assert.Throws<InvalidOperationException>(() => newInstanceInitializer(Array.Empty<object?>()));
@@ -207,7 +207,7 @@ public class ExpressionsExtensionsTests
         var constructor = typeof(ModelWithConstructors).GetConstructor(Array.Empty<Type>());
         Assert.NotNull(constructor);
         
-        var newInstanceInitializerExpression = constructor.ConstructObjectInitializer<ModelWithConstructors>();
+        var newInstanceInitializerExpression = constructor.ConstructObjectInitializer<ModelWithConstructors>(includeParametersCountValidation: true);
         var newInstanceInitializer = newInstanceInitializerExpression.Compile();
 
         Assert.Throws<InvalidOperationException>(() => newInstanceInitializer(new object?[] { 15 }));

--- a/TryAtSoftware.Extensions.Reflection.Tests/ExpressionsExtensionsTests.cs
+++ b/TryAtSoftware.Extensions.Reflection.Tests/ExpressionsExtensionsTests.cs
@@ -202,6 +202,18 @@ public class ExpressionsExtensionsTests
     }
 
     [Fact]
+    public void ObjectInitializerShouldThrowExceptionIfMoreParametersAreProvided()
+    {
+        var constructor = typeof(ModelWithConstructors).GetConstructor(Array.Empty<Type>());
+        Assert.NotNull(constructor);
+        
+        var newInstanceInitializerExpression = constructor.ConstructObjectInitializer<ModelWithConstructors>();
+        var newInstanceInitializer = newInstanceInitializerExpression.Compile();
+
+        Assert.Throws<InvalidOperationException>(() => newInstanceInitializer(new object?[] { 15 }));
+    }
+
+    [Fact]
     public void ObjectInitializerShouldNotBeConstructedIfTheReflectedTypeDoesNotCorrespondToTheProvidedGenericTypeParameter()
     {
         var personConstructor = typeof(Person).GetConstructor(Array.Empty<Type>());

--- a/TryAtSoftware.Extensions.Reflection.Tests/ExpressionsExtensionsTests.cs
+++ b/TryAtSoftware.Extensions.Reflection.Tests/ExpressionsExtensionsTests.cs
@@ -156,7 +156,7 @@ public class ExpressionsExtensionsTests
             BindingFlags.Public | BindingFlags.Instance);
         Assert.Equal(4, constructorsBinder.MemberInfos.Count);
 
-        var predefinedParameterValues = new Dictionary<Type, object?>() { { typeof(string), text }, { typeof(int), number }, { typeof(char), symbol } };
+        var predefinedParameterValues = new Dictionary<Type, object?> { { typeof(string), text }, { typeof(int), number }, { typeof(char), symbol } };
 
         var constructorId = 1;
         foreach (var (_, member) in constructorsBinder.MemberInfos.OrderByDescending(x => x.Key))
@@ -187,6 +187,18 @@ public class ExpressionsExtensionsTests
         Assert.Equal(text, instance.Text);
         Assert.Equal(number, instance.Number);
         Assert.Equal(symbol, instance.Symbol);
+    }
+
+    [Fact]
+    public void ObjectInitializerShouldThrowExceptionIfLessParametersAreProvided()
+    {
+        var constructor = typeof(ModelWithConstructors).GetConstructor(new[] { typeof(string), typeof(int), typeof(char) });
+        Assert.NotNull(constructor);
+        
+        var newInstanceInitializerExpression = constructor.ConstructObjectInitializer<ModelWithConstructors>();
+        var newInstanceInitializer = newInstanceInitializerExpression.Compile();
+
+        Assert.Throws<InvalidOperationException>(() => newInstanceInitializer(Array.Empty<object?>()));
     }
 
     [Fact]

--- a/TryAtSoftware.Extensions.Reflection/ExpressionsExtensions.cs
+++ b/TryAtSoftware.Extensions.Reflection/ExpressionsExtensions.cs
@@ -89,6 +89,11 @@ public static class ExpressionsExtensions
     /// </summary>
     /// <param name="constructorInfo">The <see cref="ConstructorInfo"/> describing the constructor that should be used during the instantiation process.</param>
     /// <typeparam name="T">The type of object to be instantiated (should be equal to the reflected type of the extended <paramref name="constructorInfo"/>).</typeparam>
+    /// <remarks>
+    /// An expression constructed by this extension method can be compiled to a function that accepts an array of values that correspond to the parameters of the extended <paramref name="constructorInfo"/>.
+    /// Upon invocation, the compiled function will validate that the count of the provided values equals strictly the count of parameters of the extended <paramref name="constructorInfo"/>.
+    /// If any of the parameters is optional and its default value should be used, the corresponding element (from the provided array) must be <c>null</c>.
+    /// </remarks>
     /// <returns>Returns a subsequently built expression for constructing a new instance of type <typeparamref name="T"/>.</returns>
     /// <exception cref="ArgumentNullException">Thrown if the provided <paramref name="constructorInfo"/> is null.</exception>
     /// <exception cref="InvalidOperationException">Thrown if the <see cref="MemberInfo.ReflectedType"/> of the provided <paramref name="constructorInfo"/> does not match <typeparamref name="T"/>.</exception>

--- a/TryAtSoftware.Extensions.Reflection/ExpressionsExtensions.cs
+++ b/TryAtSoftware.Extensions.Reflection/ExpressionsExtensions.cs
@@ -106,14 +106,21 @@ public static class ExpressionsExtensions
         var parameters = constructorInfo.GetParameters();
         var parameterExpressions = new Expression[parameters.Length];
 
+        var requiredParameters = 0;
         for (var i = 0; i < parameters.Length; i++)
         {
             parameterExpressions[i] = Expression.ArrayIndex(argumentsParameter, Expression.Constant(i));
             if (parameters[i].HasDefaultValue) parameterExpressions[i] = Expression.Coalesce(parameterExpressions[i], Expression.Constant(parameters[i].DefaultValue));
+            else requiredParameters++;
+            
             if (parameters[i].ParameterType != typeof(object)) parameterExpressions[i] = Expression.Convert(parameterExpressions[i], parameters[i].ParameterType);
         }
 
-        var initializeExpression = Expression.New(constructorInfo, parameterExpressions);
+        var initializeExpression = Expression.Block(
+                Expression.IfThen(
+                    Expression.LessThan(Expression.ArrayLength(argumentsParameter), Expression.Constant(requiredParameters)),
+                    Expression.Throw(Expression.Constant(new InvalidOperationException("Not enough arguments are provided")))),
+                Expression.New(constructorInfo, parameterExpressions));
         return Expression.Lambda<Func<object?[], T>>(initializeExpression, argumentsParameter);
     }
 

--- a/TryAtSoftware.Extensions.Reflection/ExpressionsExtensions.cs
+++ b/TryAtSoftware.Extensions.Reflection/ExpressionsExtensions.cs
@@ -118,7 +118,7 @@ public static class ExpressionsExtensions
             if (parameters[i].ParameterType != typeof(object)) parameterExpressions[i] = Expression.Convert(parameterExpressions[i], parameters[i].ParameterType);
         }
 
-        var incorrectParametersLengthException = new InvalidOperationException($"The object initializer requires {parameters.Length} provided parameters.");
+        var incorrectParametersLengthException = new InvalidOperationException($"The object initializer requires {parameters.Length} parameters to be provided.");
         var validateParametersLengthExpression = Expression.IfThen(Expression.NotEqual(Expression.ArrayLength(argumentsParameter), Expression.Constant(parameters.Length)), Expression.Throw(Expression.Constant(incorrectParametersLengthException))); 
         var initializeExpression = Expression.Block(validateParametersLengthExpression, Expression.New(constructorInfo, parameterExpressions));
         return Expression.Lambda<Func<object?[], T>>(initializeExpression, argumentsParameter);

--- a/TryAtSoftware.Extensions.Reflection/ExpressionsExtensions.cs
+++ b/TryAtSoftware.Extensions.Reflection/ExpressionsExtensions.cs
@@ -88,17 +88,17 @@ public static class ExpressionsExtensions
     /// Use this method in order to construct an <see cref="Expression"/> for instantiation an object of type <typeparamref name="T"/> using the requested <paramref name="constructorInfo"/>.
     /// </summary>
     /// <param name="constructorInfo">The <see cref="ConstructorInfo"/> describing the constructor that should be used during the instantiation process.</param>
+    /// <param name="includeParametersCountValidation">A boolean indicating whether or not the subsequently constructed expression should include a check to validate the correct count of provided values.</param>
     /// <typeparam name="T">The type of object to be instantiated (should be equal to the reflected type of the extended <paramref name="constructorInfo"/>).</typeparam>
     /// <remarks>
     /// An expression constructed by this extension method can be compiled to a function that accepts an array of values that correspond to the parameters of the extended <paramref name="constructorInfo"/>.
-    /// Upon invocation, the compiled function will validate that the count of the provided values equals strictly the count of parameters of the extended <paramref name="constructorInfo"/>.
     /// If any of the parameters is optional and its default value should be used, the corresponding element (from the provided array) must be <c>null</c>.
     /// </remarks>
     /// <returns>Returns a subsequently built expression for constructing a new instance of type <typeparamref name="T"/>.</returns>
     /// <exception cref="ArgumentNullException">Thrown if the provided <paramref name="constructorInfo"/> is null.</exception>
     /// <exception cref="InvalidOperationException">Thrown if the <see cref="MemberInfo.ReflectedType"/> of the provided <paramref name="constructorInfo"/> does not match <typeparamref name="T"/>.</exception>
     /// <exception cref="InvalidOperationException">Thrown if the provided <paramref name="constructorInfo"/> is a constructor of an abstract class.</exception>
-    public static Expression<Func<object?[], T>> ConstructObjectInitializer<T>(this ConstructorInfo constructorInfo)
+    public static Expression<Func<object?[], T>> ConstructObjectInitializer<T>(this ConstructorInfo constructorInfo, bool includeParametersCountValidation = false)
     {
         if (constructorInfo is null) throw new ArgumentNullException(nameof(constructorInfo));
         ValidateCorrectReflectedType(constructorInfo, typeof(T));
@@ -118,9 +118,14 @@ public static class ExpressionsExtensions
             if (parameters[i].ParameterType != typeof(object)) parameterExpressions[i] = Expression.Convert(parameterExpressions[i], parameters[i].ParameterType);
         }
 
-        var incorrectParametersLengthException = new InvalidOperationException($"The object initializer requires {parameters.Length} parameters to be provided.");
-        var validateParametersLengthExpression = Expression.IfThen(Expression.NotEqual(Expression.ArrayLength(argumentsParameter), Expression.Constant(parameters.Length)), Expression.Throw(Expression.Constant(incorrectParametersLengthException))); 
-        var initializeExpression = Expression.Block(validateParametersLengthExpression, Expression.New(constructorInfo, parameterExpressions));
+        Expression initializeExpression = Expression.New(constructorInfo, parameterExpressions);
+        if (includeParametersCountValidation)
+        {
+            var incorrectParametersLengthException = new InvalidOperationException($"The object initializer requires {parameters.Length} parameters to be provided.");
+            var validateParametersLengthExpression = Expression.IfThen(Expression.NotEqual(Expression.ArrayLength(argumentsParameter), Expression.Constant(parameters.Length)), Expression.Throw(Expression.Constant(incorrectParametersLengthException)));
+            initializeExpression = Expression.Block(validateParametersLengthExpression, initializeExpression);
+        }
+
         return Expression.Lambda<Func<object?[], T>>(initializeExpression, argumentsParameter);
     }
 


### PR DESCRIPTION
Added an if-condition to the `object initialization` expression that validates the length of the provided parameter values.