### PR TITLE
Increased the `TryAtSoftware.Extensions` package suite version to 1.1.1

### DIFF
--- a/TryAtSoftware.Extensions.Reflection/TryAtSoftware.Extensions.Reflection.csproj
+++ b/TryAtSoftware.Extensions.Reflection/TryAtSoftware.Extensions.Reflection.csproj
@@ -6,7 +6,7 @@
         <Nullable>enable</Nullable>
 
         <PackageId>TryAtSoftware.Extensions.Reflection</PackageId>
-        <Version>1.1.1-alpha.6</Version>
+        <Version>1.1.1</Version>
         <Authors>Tony Troeff</Authors>
         <RepositoryUrl>https://github.com/TryAtSoftware/Extensions</RepositoryUrl>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
This PR will introduce a new minor release for the `TryAtSoftware.Extensions` package suite.

### Remarks:
- Every package that has been changed since the previous release will be updated
- The next minor version of every package should be 1.1.2