### PR TITLE
Publish `TryAtSoftware.Extensions.DependencyInjection`

### DIFF
--- a/.github/workflows/Publish packages.yml
+++ b/.github/workflows/Publish packages.yml
@@ -30,5 +30,8 @@ jobs:
     - name: Pack 'Reflection extensions'
       run: dotnet pack --no-build --configuration "${{ env.CONFIGURATION }}" ./TryAtSoftware.Extensions.Reflection/TryAtSoftware.Extensions.Reflection.csproj -o "${{ env.PACKAGES_DIRECTORY }}"
 
+    - name: Pack 'Dependency injection extensions'
+      run: dotnet pack --no-build --configuration "${{ env.CONFIGURATION }}" ./TryAtSoftware.Extensions.DependencyInjection/TryAtSoftware.Extensions.DependencyInjection.csproj -o "${{ env.PACKAGES_DIRECTORY }}"
+
     - name: Publish all packages
       run: dotnet nuget push "${{ env.PACKAGES_DIRECTORY }}/*.nupkg" --source "${{ env.NUGET_SOURCE }}" --api-key "${{ env.NUGET_KEY }}" --skip-duplicate


### PR DESCRIPTION
## Pull Request Description 

Added a new workflow step to publish the `TryAtSoftware.Extensions.DependencyInjection` package

## Motivation and Context

Whenever a new version of the `TryAtSoftware.Extensions.DependencyInjection` is released, it should be uploaded to NuGet as fast as possible.