### PR TITLE
Implement the `FindLeastSignificantUnsetBit` method

### DIFF
--- a/TryAtSoftware.Extensions.Collections.Tests/BitmaskTests.cs
+++ b/TryAtSoftware.Extensions.Collections.Tests/BitmaskTests.cs
@@ -137,7 +137,7 @@ public class BitmaskTests
     }
 
     [Fact]
-    public void FindLeastSignificantSetBitShouldWorkCorrectlyWithZeroBitmask()
+    public void FindLeastSignificantSetBitShouldWorkCorrectlyWithBitmaskOfZeros()
     {
         var bitmask = InstantiateBitmask();
         Assert.Equal(-1, bitmask.FindLeastSignificantSetBit());
@@ -167,6 +167,40 @@ public class BitmaskTests
             Assert.True(bitmask.IsSet(result));
 
             for (var j = result + 1; j < bitmask.Length; j++) Assert.False(bitmask.IsSet(j));
+        }
+    }
+
+    [Fact]
+    public void FindLeastSignificantUnsetBitShouldWorkCorrectlyWithBitmaskOfOnes()
+    {
+        var bitmask = InstantiateBitmask(initializeWithZeros: false);
+        Assert.Equal(-1, bitmask.FindLeastSignificantUnsetBit());
+    }
+
+    [Fact]
+    public void FindLeastSignificantUnsetBitShouldWorkCorrectlyInGeneral()
+    {
+        var bitmask = InstantiateBitmask(initializeWithZeros: true);
+        for (var i = bitmask.Length - 1; i >= 0; i--)
+        {
+            var result = bitmask.FindLeastSignificantUnsetBit();
+            Assert.Equal(i, result);
+
+            bitmask.Set(i);
+        }
+    }
+
+    [Fact]
+    public void FindLeastSignificantUnsetBitShouldWorkCorrectlyWithRandomBitmask()
+    {
+        for (var i = 0; i < 100; i++)
+        {
+            var bitmask = GenerateBitmask();
+
+            var result = bitmask.FindLeastSignificantUnsetBit();
+            Assert.False(bitmask.IsSet(result));
+
+            for (var j = result + 1; j < bitmask.Length; j++) Assert.True(bitmask.IsSet(j));
         }
     }
 

--- a/TryAtSoftware.Extensions.Collections.md
+++ b/TryAtSoftware.Extensions.Collections.md
@@ -132,7 +132,7 @@ Bitmask notResult2 = ~bitmask2; // 10011010
 
 #### Find the position of the least significant set bit
 
-The `FindLeastSignificantSetBit` method can be used to find the position of the least significant set bit.
+The `FindLeastSignificantSetBit` method can be used to find the position of the least significant **set** bit.
 If there are no set bits, the returned value will be `-1`.
 
 ```C#
@@ -148,6 +148,26 @@ var position2 = bitmask.FindLeastSignificantSetBit(); // 1
 
 bitmask.Unset(1); // 00000000
 var position3 = bitmask.FindLeastSignificantSetBit(); // -1
+```
+
+#### Find the position of the least significant unset bit
+
+The `FindLeastSignificantUnsetBit` method can be used to find the position of the least significant **unset** bit.
+If there are no unset bits, the returned value will be `-1`.
+
+```C#
+Bitmask bitmask = new Bitmask(8, initializeWithZeros: false);
+
+// Unset the corresponding bits so the second bitmask looks like this: 11101101
+bitmask.Unset(3); bitmask.Unset(6);
+
+var position1 = bitmask.FindLeastSignificantUnsetBit(); // 6
+
+bitmask.Set(6); // 11101111
+var position2 = bitmask.FindLeastSignificantUnsetBit(); // 3
+
+bitmask.Set(3); // 11111111
+var position3 = bitmask.FindLeastSignificantUnsetBit(); // -1
 ```
 
 ## Collection extensions

--- a/TryAtSoftware.Extensions.Collections/Bitmask.cs
+++ b/TryAtSoftware.Extensions.Collections/Bitmask.cs
@@ -86,39 +86,13 @@ public class Bitmask
     /// Use this method to find the position of the least significant (right-most) bit that is set.
     /// </summary>
     /// <returns>Returns the position of the least significant set bit. Returns -1 if there are no set bits.</returns>
-    public int FindLeastSignificantSetBit()
-    {
-        for (var i = this._segments.Count - 1; i >= 0; i--)
-        {
-            var currentSegment = this._segments[i];
-            if (currentSegment == ZeroSegment) continue;
-
-            return (i * BitsPerSegment + BitsPerSegment - (Bits.TrailingZeroCount(currentSegment) + 1));
-        }
-
-        return -1;
-    }
+    public int FindLeastSignificantSetBit() => this.FindLeastSignificantSetBit(inverse: false);
 
     /// <summary>
     /// Use this method to find the position of the least significant (right-most) bit that is unset.
     /// </summary>
     /// <returns>Returns the position of the least significant unset bit. Returns -1 if there are no set bits.</returns>
-    public int FindLeastSignificantUnsetBit()
-    {
-        for (var i = this._segments.Count - 1; i >= 0; i--)
-        {
-            var currentSegment = this._segments[i];
-
-            var inversedSegment = ~currentSegment;
-            if (i == this._segments.Count - 1) inversedSegment = this.ApplyLastSegmentMask(inversedSegment);
-
-            if (inversedSegment == ZeroSegment) continue;
-
-            return (i * BitsPerSegment + BitsPerSegment - (Bits.TrailingZeroCount(inversedSegment) + 1));
-        }
-
-        return -1;
-    }
+    public int FindLeastSignificantUnsetBit() => this.FindLeastSignificantSetBit(inverse: true);
 
     /// <inheritdoc />
     public override string ToString()
@@ -187,6 +161,25 @@ public class Bitmask
         }
 
         return result;
+    }
+    
+    private int FindLeastSignificantSetBit(bool inverse)
+    {
+        for (var i = this._segments.Count - 1; i >= 0; i--)
+        {
+            var currentSegment = this._segments[i];
+            if (inverse)
+            {
+                currentSegment = ~currentSegment;
+                if (i == this._segments.Count - 1) currentSegment = this.ApplyLastSegmentMask(currentSegment);
+            }
+            
+            if (currentSegment == ZeroSegment) continue;
+
+            return (i * BitsPerSegment + BitsPerSegment - (Bits.TrailingZeroCount(currentSegment) + 1));
+        }
+
+        return -1;
     }
 
     private void SetSegment(int index, ulong value)

--- a/TryAtSoftware.Extensions.Collections/Bitmask.cs
+++ b/TryAtSoftware.Extensions.Collections/Bitmask.cs
@@ -99,6 +99,27 @@ public class Bitmask
         return -1;
     }
 
+    /// <summary>
+    /// Use this method to find the position of the least significant (right-most) bit that is unset.
+    /// </summary>
+    /// <returns>Returns the position of the least significant unset bit. Returns -1 if there are no set bits.</returns>
+    public int FindLeastSignificantUnsetBit()
+    {
+        for (var i = this._segments.Count - 1; i >= 0; i--)
+        {
+            var currentSegment = this._segments[i];
+
+            var inversedSegment = ~currentSegment;
+            if (i == this._segments.Count - 1) inversedSegment = this.ApplyLastSegmentMask(inversedSegment);
+
+            if (inversedSegment == ZeroSegment) continue;
+
+            return (i * BitsPerSegment + BitsPerSegment - (Bits.TrailingZeroCount(inversedSegment) + 1));
+        }
+
+        return -1;
+    }
+
     /// <inheritdoc />
     public override string ToString()
     {
@@ -185,5 +206,7 @@ public class Bitmask
         return (segmentIndex, BitsPerSegment - (bitIndex + 1));
     }
 
-    private void NormalizeLastSegment() => this._segments[^1] &= this._lastSegmentMask;
+    private void NormalizeLastSegment() => this._segments[^1] = this.ApplyLastSegmentMask(this._segments[^1]);
+
+    private ulong ApplyLastSegmentMask(ulong segment) => segment & this._lastSegmentMask;
 }


### PR DESCRIPTION
## Pull Request Description 

Implemented a method that should return the position of the least significant unset bit for a given `Bitmask`.

## Motivation and Context

We have a similar method called `FindLeastSignificantSetBit` that allows us to find the position of the least significant set bit. However, the opposite is not achievable from outside of the `Bitmask` implementation. That's why we decided to expose a new method that will guarantee optimal performance.

## Checklist

- [x] I have tested these changes thoroughly.
- [x] I have added/updated relevant documentation.
- [x] My code follows the project's coding guidelines.
- [x] I have performed a self-review of my changes.
- [x] My changes are backwards compatible.
