### PR TITLE
Introduced the `SetAll` and `UnsetAll` methods for bitmasks

### DIFF
--- a/TryAtSoftware.Extensions.Collections.Tests/BitmaskTests.cs
+++ b/TryAtSoftware.Extensions.Collections.Tests/BitmaskTests.cs
@@ -36,6 +36,18 @@ public class BitmaskTests
     }
 
     [Fact]
+    public void SetAllShouldWorkCorrectlyWithRandomBitmask()
+    {
+        for (var i = 0; i < 100; i++)
+        {
+            var bitmask = GenerateBitmask();
+            bitmask.SetAll();
+            
+            for (var j = 0; j < bitmask.Length; j++) Assert.True(bitmask.IsSet(j));
+        }
+    }
+
+    [Fact]
     public void MultiUnsetShouldWorkCorrectly()
     {
         var bitmask = InstantiateBitmask(initializeWithZeros: false);
@@ -45,6 +57,18 @@ public class BitmaskTests
         {
             bitmask.Unset(randomIndex);
             for (var j = 0; j < bitmask.Length; j++) Assert.Equal(j != randomIndex, bitmask.IsSet(j));
+        }
+    }
+
+    [Fact]
+    public void UnsetAllShouldWorkCorrectlyWithRandomBitmask()
+    {
+        for (var i = 0; i < 100; i++)
+        {
+            var bitmask = GenerateBitmask();
+            bitmask.UnsetAll();
+            
+            for (var j = 0; j < bitmask.Length; j++) Assert.False(bitmask.IsSet(j));
         }
     }
 
@@ -60,18 +84,6 @@ public class BitmaskTests
     {
         var bitmask = InstantiateBitmask(initializeWithZeros: false);
         for (var i = 0; i < bitmask.Length; i++) Assert.True(bitmask.IsSet(i));
-    }
-
-    [Fact]
-    public void ClearShouldWorkCorrectlyWithRandomBitmask()
-    {
-        for (var i = 0; i < 100; i++)
-        {
-            var bitmask = GenerateBitmask();
-            bitmask.Clear();
-            
-            for (var j = 0; j < bitmask.Length; j++) Assert.False(bitmask.IsSet(j));
-        }
     }
 
     [Fact]

--- a/TryAtSoftware.Extensions.Collections.Tests/BitmaskTests.cs
+++ b/TryAtSoftware.Extensions.Collections.Tests/BitmaskTests.cs
@@ -63,6 +63,18 @@ public class BitmaskTests
     }
 
     [Fact]
+    public void ClearShouldWorkCorrectlyWithRandomBitmask()
+    {
+        for (var i = 0; i < 100; i++)
+        {
+            var bitmask = GenerateBitmask();
+            bitmask.Clear();
+            
+            for (var j = 0; j < bitmask.Length; j++) Assert.False(bitmask.IsSet(j));
+        }
+    }
+
+    [Fact]
     public void BitwiseAndShouldBeExecutedSuccessfully() => AssertCorrectBitwiseOperation((a, b) => a & b, (a, b) => a & b);
 
     [Fact]

--- a/TryAtSoftware.Extensions.Collections.md
+++ b/TryAtSoftware.Extensions.Collections.md
@@ -51,6 +51,8 @@ Bitmask bitmaskWithOnes = new Bitmask(8, initializeWithZeros: false); // 1111111
 The `Set` method can be used to set the bit at a given position.
 It accepts a single parameter - the **zero-based** position of the bit that should be set.
 
+The `SetAll` method can be used to set all bits.
+
 ```C#
 Bitmask bitmask = new Bitmask(8, initializeWithZeros: true); // 00000000
         
@@ -58,6 +60,8 @@ bitmask.Set(0); // 10000000
 bitmask.Set(3); // 10010000
 
 bitmask.Set(0); // The bit is already set - nothing will be changed.
+
+bitmask.SetAll(); // 11111111
 
 // Invalid cases - position is out of range
 bitmask.Set(-1); // Exception will be thrown!
@@ -70,6 +74,8 @@ bitmask.Set(100); // Exception will be thrown!
 The `Unset` method can be used to unset the bit at a given position.
 It accepts a single parameter - the **zero-based** position of the bit that should be unset.
 
+The `UnsetAll` method can be used to unset all bits.
+
 ```C#
 Bitmask bitmask = new Bitmask(8, initializeWithZeros: false); // 11111111
         
@@ -77,6 +83,8 @@ bitmask.Unset(1); // 10111111
 bitmask.Unset(2); // 10011111
 
 bitmask.Unset(2); // The bit is not set - nothing will be changed.
+
+bitmask.UnsetAll(); // 00000000
 
 // Invalid cases - position is out of range
 bitmask.Unset(-1); // Exception will be thrown!

--- a/TryAtSoftware.Extensions.Collections/Bitmask.cs
+++ b/TryAtSoftware.Extensions.Collections/Bitmask.cs
@@ -62,6 +62,15 @@ public class Bitmask
     }
 
     /// <summary>
+    /// Use this method to set all bits.
+    /// </summary>
+    public void SetAll()
+    {
+        for (var i = 0; i < this.SegmentsCount; i++)
+            this.SetSegment(i, OneSegment);
+    }
+
+    /// <summary>
     /// Use this method to unset the bit at the requested position.
     /// </summary>
     /// <param name="position">The position of the bit that should be unset.</param>
@@ -69,6 +78,15 @@ public class Bitmask
     {
         var (segmentIndex, bitIndex) = this.Locate(position);
         this._segments[segmentIndex] &= ~(1UL << bitIndex);
+    }
+
+    /// <summary>
+    /// Use this method to unset all bits.
+    /// </summary>
+    public void UnsetAll()
+    {
+        for (var i = 0; i < this.SegmentsCount; i++)
+            this.SetSegment(i, ZeroSegment);
     }
 
     /// <summary>
@@ -80,12 +98,6 @@ public class Bitmask
     {
         var (segmentIndex, bitIndex) = this.Locate(position);
         return (this._segments[segmentIndex] & (1UL << bitIndex)) != 0;
-    }
-
-    public void Clear()
-    {
-        for (var i = 0; i < this.SegmentsCount; i++)
-            this.SetSegment(i, ZeroSegment);
     }
     
     /// <summary>

--- a/TryAtSoftware.Extensions.Collections/Bitmask.cs
+++ b/TryAtSoftware.Extensions.Collections/Bitmask.cs
@@ -82,6 +82,12 @@ public class Bitmask
         return (this._segments[segmentIndex] & (1UL << bitIndex)) != 0;
     }
 
+    public void Clear()
+    {
+        for (var i = 0; i < this.SegmentsCount; i++)
+            this.SetSegment(i, ZeroSegment);
+    }
+    
     /// <summary>
     /// Use this method to find the position of the least significant (right-most) bit that is set.
     /// </summary>


### PR DESCRIPTION
## Pull Request Description 

Implemented, documented and tested the new `SetAll` and `UnsetAll` methods for the `Bitmask` class.

## Motivation and Context

We need a method to set/unset all bits of a bitmask without allocating additional memory.

## Checklist

- [x] I have tested these changes thoroughly.
- [x] I have added/updated relevant documentation.
- [x] My code follows the project's coding guidelines.
- [x] I have performed a self-review of my changes.
- [x] My changes are backwards compatible.
