### PR TITLE
In-place bitwise operations

### DIFF
--- a/TryAtSoftware.Extensions.Collections.Tests/BitmaskTests.cs
+++ b/TryAtSoftware.Extensions.Collections.Tests/BitmaskTests.cs
@@ -88,45 +88,39 @@ public class BitmaskTests
 
     [Fact]
     public void BitwiseAndShouldBeExecutedSuccessfully() => AssertCorrectBitwiseOperation((a, b) => a & b, (a, b) => a & b);
+    
+    [Fact]
+    public void BitwiseAndShouldBeExecutedSuccessfullyInplace() => AssertCorrectInplaceBitwiseOperation((a, b) => a.InplaceAnd(b), (a, b) => a & b);
 
     [Fact]
     public void BitwiseAndShouldBeExecutedSuccessfullyWhenLengthIsDifferent() => AssertCorrectBitwiseOperation((a, b) => a & b, (a, b) => a & b, lengthDifferenceInSegments: RandomBitmaskLength());
 
     [Fact]
-    public void BitwiseAndShouldValidateItsArguments()
-    {
-        var bitmask = GenerateBitmask();
-        Assert.Throws<ArgumentNullException>(() => bitmask & null!);
-        Assert.Throws<ArgumentNullException>(() => null! & bitmask);
-    }
+    public void BitwiseAndShouldValidateItsArguments() => AssertBitwiseOperandsAreValidatedSuccessfully((a, b) => a & b, (a, b) => a.InplaceAnd(b));
 
     [Fact]
     public void BitwiseOrShouldBeExecutedSuccessfully() => AssertCorrectBitwiseOperation((a, b) => a | b, (a, b) => a | b);
+    
+    [Fact]
+    public void BitwiseOrShouldBeExecutedSuccessfullyInplace() => AssertCorrectInplaceBitwiseOperation((a, b) => a.InplaceOr(b), (a, b) => a | b);
 
     [Fact]
     public void BitwiseOrShouldBeExecutedSuccessfullyWhenLengthIsDifferent() => AssertCorrectBitwiseOperation((a, b) => a | b, (a, b) => a | b, lengthDifferenceInSegments: RandomBitmaskLength());
 
     [Fact]
-    public void BitwiseOrShouldValidateItsArguments()
-    {
-        var bitmask = GenerateBitmask();
-        Assert.Throws<ArgumentNullException>(() => bitmask | null!);
-        Assert.Throws<ArgumentNullException>(() => null! | bitmask);
-    }
+    public void BitwiseOrShouldValidateItsArguments() => AssertBitwiseOperandsAreValidatedSuccessfully((a, b) => a | b, (a, b) => a.InplaceOr(b));
 
     [Fact]
     public void BitwiseXorShouldBeExecutedSuccessfully() => AssertCorrectBitwiseOperation((a, b) => a ^ b, (a, b) => a ^ b);
+    
+    [Fact]
+    public void BitwiseXorShouldBeExecutedSuccessfullyInplace() => AssertCorrectInplaceBitwiseOperation((a, b) => a.InplaceXor(b), (a, b) => a ^ b);
 
     [Fact]
     public void BitwiseXorShouldBeExecutedSuccessfullyWhenLengthIsDifferent() => AssertCorrectBitwiseOperation((a, b) => a ^ b, (a, b) => a ^ b, lengthDifferenceInSegments: RandomBitmaskLength());
 
     [Fact]
-    public void BitwiseXorShouldValidateItsArguments()
-    {
-        var bitmask = GenerateBitmask();
-        Assert.Throws<ArgumentNullException>(() => bitmask ^ null!);
-        Assert.Throws<ArgumentNullException>(() => null! ^ bitmask);
-    }
+    public void BitwiseXorShouldValidateItsArguments() => AssertBitwiseOperandsAreValidatedSuccessfully((a, b) => a ^ b, (a, b) => a.InplaceXor(b));
 
     [Fact]
     public void BitwiseNotShouldBeExecutedSuccessfully()
@@ -442,6 +436,44 @@ public class BitmaskTests
             for (var i = 0; i < totalBitmaskLength; i++)
                 Assert.Equal(expected.IsSet(i), result.IsSet(i));
         }
+    }
+
+    private static void AssertCorrectInplaceBitwiseOperation(Action<Bitmask, Bitmask> executeOperationInplace, Func<bool, bool, bool> getExpectedBit)
+    {
+        var length = RandomBitmaskLength();
+
+        var originalBitmask = GenerateBitmask(length);
+        var otherBitmask = GenerateBitmask(length);
+
+        var expected = new Bitmask(length, initializeWithZeros: true);
+        var otherBitmaskCopy = new Bitmask(length, initializeWithZeros: true);
+        for (var i = 0; i < length; i++)
+        {
+            var expectedBit = getExpectedBit(originalBitmask.IsSet(i), otherBitmask.IsSet(i));
+            if (expectedBit) expected.Set(i);
+
+            if (otherBitmask.IsSet(i)) otherBitmaskCopy.Set(i);
+        }
+
+        executeOperationInplace(originalBitmask, otherBitmask);
+
+        for (var i = 0; i < length; i++)
+        {
+            Assert.Equal(expected.IsSet(i), originalBitmask.IsSet(i));
+            Assert.Equal(otherBitmaskCopy.IsSet(i), otherBitmask.IsSet(i)); // Assert the `other` bitmask instance remains unchanged.
+        }
+    }
+
+    private static void AssertBitwiseOperandsAreValidatedSuccessfully(Func<Bitmask, Bitmask, Bitmask> executeOperation, Action<Bitmask, Bitmask> executeOperationInplace)
+    {
+        var bitmask = GenerateBitmask();
+        Assert.Throws<ArgumentNullException>(() => executeOperation(bitmask, null!));
+        Assert.Throws<ArgumentNullException>(() => executeOperation(null!, bitmask));
+
+        Assert.Throws<ArgumentNullException>(() => executeOperationInplace(bitmask, null!));
+
+        var bitmaskWithDifferentLength = new Bitmask(bitmask.Length + RandomizationHelper.RandomInteger(1, 10, upperBoundIsExclusive: false), initializeWithZeros: true);
+        Assert.Throws<InvalidOperationException>(() => executeOperationInplace(bitmask, bitmaskWithDifferentLength));
     }
 
     private static void AssertCorrectRightShift(Func<Bitmask, int, Bitmask> compute)

--- a/TryAtSoftware.Extensions.Collections.Tests/BitmaskTests.cs
+++ b/TryAtSoftware.Extensions.Collections.Tests/BitmaskTests.cs
@@ -90,37 +90,37 @@ public class BitmaskTests
     public void BitwiseAndShouldBeExecutedSuccessfully() => AssertCorrectBitwiseOperation((a, b) => a & b, (a, b) => a & b);
     
     [Fact]
-    public void BitwiseAndShouldBeExecutedSuccessfullyInplace() => AssertCorrectInplaceBitwiseOperation((a, b) => a.InplaceAnd(b), (a, b) => a & b);
+    public void BitwiseAndShouldBeExecutedSuccessfullyInPlace() => AssertCorrectInPlaceBitwiseOperation((a, b) => a.InPlaceAnd(b), (a, b) => a & b);
 
     [Fact]
     public void BitwiseAndShouldBeExecutedSuccessfullyWhenLengthIsDifferent() => AssertCorrectBitwiseOperation((a, b) => a & b, (a, b) => a & b, lengthDifferenceInSegments: RandomBitmaskLength());
 
     [Fact]
-    public void BitwiseAndShouldValidateItsArguments() => AssertBitwiseOperandsAreValidatedSuccessfully((a, b) => a & b, (a, b) => a.InplaceAnd(b));
+    public void BitwiseAndShouldValidateItsArguments() => AssertBitwiseOperandsAreValidatedSuccessfully((a, b) => a & b, (a, b) => a.InPlaceAnd(b));
 
     [Fact]
     public void BitwiseOrShouldBeExecutedSuccessfully() => AssertCorrectBitwiseOperation((a, b) => a | b, (a, b) => a | b);
     
     [Fact]
-    public void BitwiseOrShouldBeExecutedSuccessfullyInplace() => AssertCorrectInplaceBitwiseOperation((a, b) => a.InplaceOr(b), (a, b) => a | b);
+    public void BitwiseOrShouldBeExecutedSuccessfullyInPlace() => AssertCorrectInPlaceBitwiseOperation((a, b) => a.InPlaceOr(b), (a, b) => a | b);
 
     [Fact]
     public void BitwiseOrShouldBeExecutedSuccessfullyWhenLengthIsDifferent() => AssertCorrectBitwiseOperation((a, b) => a | b, (a, b) => a | b, lengthDifferenceInSegments: RandomBitmaskLength());
 
     [Fact]
-    public void BitwiseOrShouldValidateItsArguments() => AssertBitwiseOperandsAreValidatedSuccessfully((a, b) => a | b, (a, b) => a.InplaceOr(b));
+    public void BitwiseOrShouldValidateItsArguments() => AssertBitwiseOperandsAreValidatedSuccessfully((a, b) => a | b, (a, b) => a.InPlaceOr(b));
 
     [Fact]
     public void BitwiseXorShouldBeExecutedSuccessfully() => AssertCorrectBitwiseOperation((a, b) => a ^ b, (a, b) => a ^ b);
     
     [Fact]
-    public void BitwiseXorShouldBeExecutedSuccessfullyInplace() => AssertCorrectInplaceBitwiseOperation((a, b) => a.InplaceXor(b), (a, b) => a ^ b);
+    public void BitwiseXorShouldBeExecutedSuccessfullyInPlace() => AssertCorrectInPlaceBitwiseOperation((a, b) => a.InPlaceXor(b), (a, b) => a ^ b);
 
     [Fact]
     public void BitwiseXorShouldBeExecutedSuccessfullyWhenLengthIsDifferent() => AssertCorrectBitwiseOperation((a, b) => a ^ b, (a, b) => a ^ b, lengthDifferenceInSegments: RandomBitmaskLength());
 
     [Fact]
-    public void BitwiseXorShouldValidateItsArguments() => AssertBitwiseOperandsAreValidatedSuccessfully((a, b) => a ^ b, (a, b) => a.InplaceXor(b));
+    public void BitwiseXorShouldValidateItsArguments() => AssertBitwiseOperandsAreValidatedSuccessfully((a, b) => a ^ b, (a, b) => a.InPlaceXor(b));
 
     [Fact]
     public void BitwiseNotShouldBeExecutedSuccessfully()
@@ -438,7 +438,7 @@ public class BitmaskTests
         }
     }
 
-    private static void AssertCorrectInplaceBitwiseOperation(Action<Bitmask, Bitmask> executeOperationInplace, Func<bool, bool, bool> getExpectedBit)
+    private static void AssertCorrectInPlaceBitwiseOperation(Action<Bitmask, Bitmask> executeOperationInPlace, Func<bool, bool, bool> getExpectedBit)
     {
         var length = RandomBitmaskLength();
 
@@ -455,7 +455,7 @@ public class BitmaskTests
             if (otherBitmask.IsSet(i)) otherBitmaskCopy.Set(i);
         }
 
-        executeOperationInplace(originalBitmask, otherBitmask);
+        executeOperationInPlace(originalBitmask, otherBitmask);
 
         for (var i = 0; i < length; i++)
         {
@@ -464,16 +464,16 @@ public class BitmaskTests
         }
     }
 
-    private static void AssertBitwiseOperandsAreValidatedSuccessfully(Func<Bitmask, Bitmask, Bitmask> executeOperation, Action<Bitmask, Bitmask> executeOperationInplace)
+    private static void AssertBitwiseOperandsAreValidatedSuccessfully(Func<Bitmask, Bitmask, Bitmask> executeOperation, Action<Bitmask, Bitmask> executeOperationInPlace)
     {
         var bitmask = GenerateBitmask();
         Assert.Throws<ArgumentNullException>(() => executeOperation(bitmask, null!));
         Assert.Throws<ArgumentNullException>(() => executeOperation(null!, bitmask));
 
-        Assert.Throws<ArgumentNullException>(() => executeOperationInplace(bitmask, null!));
+        Assert.Throws<ArgumentNullException>(() => executeOperationInPlace(bitmask, null!));
 
         var bitmaskWithDifferentLength = new Bitmask(bitmask.Length + RandomizationHelper.RandomInteger(1, 10, upperBoundIsExclusive: false), initializeWithZeros: true);
-        Assert.Throws<InvalidOperationException>(() => executeOperationInplace(bitmask, bitmaskWithDifferentLength));
+        Assert.Throws<InvalidOperationException>(() => executeOperationInPlace(bitmask, bitmaskWithDifferentLength));
     }
 
     private static void AssertCorrectRightShift(Func<Bitmask, int, Bitmask> compute)

--- a/TryAtSoftware.Extensions.Collections.md
+++ b/TryAtSoftware.Extensions.Collections.md
@@ -118,6 +118,9 @@ Bitwise operations can be executed by using the corresponding operators.
 _They can come in handy whenever it is required to work over a group of bits collectively, rather than individually._
 The produced result will be a `Bitmask` instance as well.
 
+> The operations bitwise-and, bitwise-or and exclusive-or do not require both of the operands to have the same length.
+> You can visualize this by padding the shorter bitmask with enough **trailing** zeros.
+
 > For .NET 7 or above the `Bitmask` type implements the `IBitwiseOperators<Bitmask, Bitmask, Bitmask>` and `IShiftOperators<Bitmask, int, Bitmask>` interfaces.
 
 ```C#
@@ -140,6 +143,36 @@ Bitmask rightShiftResult = bitmask2 >> 2; // 00011001
 
 Bitmask notResult1 = ~bitmask1; // 00101011
 Bitmask notResult2 = ~bitmask2; // 10011010
+```
+
+#### Executing in-place bitwise operations
+
+We can use in-place bitwise operations in order to save up some memory whenever it is not required for the produced result of the operation to be a new `Bitmask` instance.
+For this purpose, the `InPlaceAnd`, `InPlaceOr` and `InPlaceXor` methods can be used.
+
+> In-place bitwise operations require both of the bitmasks to have the exact same length.
+
+```C#
+Bitmask bitmask1 = new Bitmask(8, initializeWithZeros: true);
+Bitmask bitmask2 = new Bitmask(8, initializeWithZeros: true);
+Bitmask bitmask3 = new Bitmask(8, initializeWithZeros: true);
+Bitmask bitmask4 = new Bitmask(8, initializeWithZeros: true);
+
+// Set the corresponding bits so the first bitmask looks like this: 11010100
+bitmask1.Set(0); bitmask1.Set(1); bitmask1.Set(3); bitmask1.Set(5);
+
+// Set the corresponding bits so the second bitmask looks like this: 01100101
+bitmask2.Set(1); bitmask2.Set(2); bitmask2.Set(5); bitmask2.Set(7);
+
+// Set the corresponding bits so the third bitmask looks like this: 01001011
+bitmask3.Set(1); bitmask3.Set(4); bitmask3.Set(6); bitmask3.Set(7);
+
+// Set the corresponding bits so the fourth bitmask looks like this: 11000010
+bitmask4.Set(0); bitmask4.Set(1); bitmask4.Set(6);
+
+bitmask1.InPlaceAnd(bitmask2); // bitmask1 changes to 01000100; bitmask2 remains unchanged
+bitmask2.InPlaceOr(bitmask3); // bitmask2 changes to 01101111; bitmask3 remains unchanged
+bitmask3.InPlaceXor(bitmask4); // bitmask3 changes to 10001001; bitmask4 remains unchanged
 ```
 
 #### Find the position of the most significant set bit

--- a/TryAtSoftware.Extensions.Collections.md
+++ b/TryAtSoftware.Extensions.Collections.md
@@ -118,7 +118,7 @@ Bitwise operations can be executed by using the corresponding operators.
 _They can come in handy whenever it is required to work over a group of bits collectively, rather than individually._
 The produced result will be a `Bitmask` instance as well.
 
-> The operations bitwise-and, bitwise-or and exclusive-or do not require both of the operands to have the same length.
+> The operations `bitwise-and`, `bitwise-or` and `exclusive-or` do not require both of the operands to have the same length.
 > You can visualize this by padding the shorter bitmask with enough **trailing** zeros.
 
 > For .NET 7 or above the `Bitmask` type implements the `IBitwiseOperators<Bitmask, Bitmask, Bitmask>` and `IShiftOperators<Bitmask, int, Bitmask>` interfaces.
@@ -147,7 +147,7 @@ Bitmask notResult2 = ~bitmask2; // 10011010
 
 #### Executing in-place bitwise operations
 
-We can use in-place bitwise operations in order to save up some memory whenever it is not required for the produced result of the operation to be a new `Bitmask` instance.
+We can use in-place bitwise operations in order to save up some memory whenever there is no need for the operation's result to be a new `Bitmask` instance.
 For this purpose, the `InPlaceAnd`, `InPlaceOr` and `InPlaceXor` methods can be used.
 
 > In-place bitwise operations require both of the bitmasks to have the exact same length.

--- a/TryAtSoftware.Extensions.Collections/Bitmask.cs
+++ b/TryAtSoftware.Extensions.Collections/Bitmask.cs
@@ -140,6 +140,24 @@ public class Bitmask
     /// </summary>
     public int CountUnsetBits() => this.Length - this.CountSetBits();
 
+    /// <summary>
+    /// Computes bitwise-and inplace with another two <see cref="Bitmask"/> instance.
+    /// </summary>
+    /// <param name="other">The other bitmask.</param>
+    public void InplaceAnd(Bitmask other) => this.ExecuteInplaceBitwiseOperation(other, BitwiseAnd);
+
+    /// <summary>
+    /// Computes bitwise-or inplace with another two <see cref="Bitmask"/> instance.
+    /// </summary>
+    /// <param name="other">The other bitmask.</param>
+    public void InplaceOr(Bitmask other) => this.ExecuteInplaceBitwiseOperation(other, BitwiseOr);
+
+    /// <summary>
+    /// Computes exclusive-or inplace with another two <see cref="Bitmask"/> instance.
+    /// </summary>
+    /// <param name="other">The other bitmask.</param>
+    public void InplaceXor(Bitmask other) => this.ExecuteInplaceBitwiseOperation(other, BitwiseXor);
+
     /// <inheritdoc />
     public override string ToString()
     {
@@ -275,6 +293,20 @@ public class Bitmask
         }
 
         return result;
+    }
+
+    private void ExecuteInplaceBitwiseOperation(Bitmask other, Func<ulong, ulong, ulong> operation)
+    {
+        if (other is null) throw new ArgumentNullException(nameof(other));
+        if (this.Length != other.Length) throw new InvalidOperationException("Both bitmask instances must have the same length in order to execute an inplace bitwise operation.");
+        
+        for (var i = 0; i < this.SegmentsCount; i++)
+        {
+            var left = this.GetSegment(i);
+            var right = other.GetSegment(i);
+
+            this.SetSegment(i, operation(left, right));
+        }
     }
 
     private int FindLeastSignificantSetBit(bool inverse)

--- a/TryAtSoftware.Extensions.Collections/Bitmask.cs
+++ b/TryAtSoftware.Extensions.Collections/Bitmask.cs
@@ -141,22 +141,22 @@ public class Bitmask
     public int CountUnsetBits() => this.Length - this.CountSetBits();
 
     /// <summary>
-    /// Computes bitwise-and inplace with another two <see cref="Bitmask"/> instance.
+    /// Computes bitwise-and in-place with another two <see cref="Bitmask"/> instance.
     /// </summary>
     /// <param name="other">The other bitmask.</param>
-    public void InplaceAnd(Bitmask other) => this.ExecuteInplaceBitwiseOperation(other, BitwiseAnd);
+    public void InPlaceAnd(Bitmask other) => this.ExecuteInPlaceBitwiseOperation(other, BitwiseAnd);
 
     /// <summary>
-    /// Computes bitwise-or inplace with another two <see cref="Bitmask"/> instance.
+    /// Computes bitwise-or in-place with another two <see cref="Bitmask"/> instance.
     /// </summary>
     /// <param name="other">The other bitmask.</param>
-    public void InplaceOr(Bitmask other) => this.ExecuteInplaceBitwiseOperation(other, BitwiseOr);
+    public void InPlaceOr(Bitmask other) => this.ExecuteInPlaceBitwiseOperation(other, BitwiseOr);
 
     /// <summary>
-    /// Computes exclusive-or inplace with another two <see cref="Bitmask"/> instance.
+    /// Computes exclusive-or in-place with another two <see cref="Bitmask"/> instance.
     /// </summary>
     /// <param name="other">The other bitmask.</param>
-    public void InplaceXor(Bitmask other) => this.ExecuteInplaceBitwiseOperation(other, BitwiseXor);
+    public void InPlaceXor(Bitmask other) => this.ExecuteInPlaceBitwiseOperation(other, BitwiseXor);
 
     /// <inheritdoc />
     public override string ToString()
@@ -295,10 +295,10 @@ public class Bitmask
         return result;
     }
 
-    private void ExecuteInplaceBitwiseOperation(Bitmask other, Func<ulong, ulong, ulong> operation)
+    private void ExecuteInPlaceBitwiseOperation(Bitmask other, Func<ulong, ulong, ulong> operation)
     {
         if (other is null) throw new ArgumentNullException(nameof(other));
-        if (this.Length != other.Length) throw new InvalidOperationException("Both bitmask instances must have the same length in order to execute an inplace bitwise operation.");
+        if (this.Length != other.Length) throw new InvalidOperationException("Both bitmask instances must have the same length in order to execute an in-place bitwise operation.");
         
         for (var i = 0; i < this.SegmentsCount; i++)
         {


### PR DESCRIPTION
## Pull Request Description 

Implemented, documented and tested the new `InPlaceAnd`, `InPlaceOr` and `InPlaceXor` methods for the `Bitmask` class.

## Motivation and Context

We need to execute bitwise operation in-place in order to save up unnecessarily allocated memory.

## Checklist

- [x] I have tested these changes thoroughly.
- [x] I have added/updated relevant documentation.
- [x] My code follows the project's coding guidelines.
- [x] I have performed a self-review of my changes.
- [x] My changes are backwards compatible.
