### PR TITLE
Introduced the `HasCommonSetBitsWith` method for bitmasks

### DIFF
--- a/TryAtSoftware.Extensions.Collections.Tests/BitmaskTests.cs
+++ b/TryAtSoftware.Extensions.Collections.Tests/BitmaskTests.cs
@@ -3,9 +3,47 @@
 using System;
 using TryAtSoftware.Randomizer.Core.Helpers;
 using Xunit;
+using Xunit.Abstractions;
 
 public class BitmaskTests
 {
+    private readonly ITestOutputHelper _testOutputHelper;
+
+    public BitmaskTests(ITestOutputHelper testOutputHelper)
+    {
+        this._testOutputHelper = testOutputHelper ?? throw new ArgumentNullException(nameof(testOutputHelper));
+    }
+
+    [Fact]
+    public void Test()
+    {
+        Bitmask bitmask1 = new Bitmask(8, initializeWithZeros: true);
+        Bitmask bitmask2 = new Bitmask(8, initializeWithZeros: true);
+        Bitmask bitmask3 = new Bitmask(8, initializeWithZeros: true);
+        Bitmask bitmask4 = new Bitmask(8, initializeWithZeros: true);
+
+        // Set the corresponding bits so the first bitmask looks like this: 11010100
+        bitmask1.Set(0); bitmask1.Set(1); bitmask1.Set(3); bitmask1.Set(5);
+
+        // Set the corresponding bits so the second bitmask looks like this: 01100101
+        bitmask2.Set(1); bitmask2.Set(2); bitmask2.Set(5); bitmask2.Set(7);
+        
+        // Set the corresponding bits so the third bitmask looks like this: 01001011
+        bitmask3.Set(1); bitmask3.Set(4); bitmask3.Set(6); bitmask3.Set(7);
+        
+        // Set the corresponding bits so the fourth bitmask looks like this: 11000010
+        bitmask4.Set(0); bitmask4.Set(1); bitmask4.Set(6);
+
+        bitmask1.InPlaceAnd(bitmask2); // bitmask1: 01000100; bitmask2 remains unchanged
+        bitmask2.InPlaceOr(bitmask3); // bitmask2: 01101111; bitmask3 remains unchanged
+        bitmask3.InPlaceXor(bitmask4); // bitmask3: 10001001; bitmask4 remains unchanged
+        
+        this._testOutputHelper.WriteLine(bitmask1.ToString());
+        this._testOutputHelper.WriteLine(bitmask2.ToString());
+        this._testOutputHelper.WriteLine(bitmask3.ToString());
+        this._testOutputHelper.WriteLine(bitmask4.ToString());
+    }
+
     [Fact]
     public void BitsShouldBeIndexedSuccessfully()
     {
@@ -378,6 +416,36 @@ public class BitmaskTests
             
             Assert.Equal(expected, bitmask.CountUnsetBits());
         }
+    }
+
+    [Fact]
+    public void HasCommonBitsWithShouldValidateItsArguments()
+    {
+        var bitmask = GenerateBitmask();
+        Assert.Throws<ArgumentNullException>(() => bitmask.HasCommonSetBitsWith(null!));
+    }
+
+    [Fact]
+    public void HasCommonBitsWithShouldWorkCorrectlyBitmasksOfSameLength()
+    {
+        var bitmask = GenerateBitmask();
+        var zeroBitmask = new Bitmask(bitmask.Length, initializeWithZeros: true);
+        var oneBitmask = new Bitmask(bitmask.Length, initializeWithZeros: false);
+        
+        Assert.False(bitmask.HasCommonSetBitsWith(~bitmask));
+        Assert.False(bitmask.HasCommonSetBitsWith(zeroBitmask));
+        Assert.True(bitmask.HasCommonSetBitsWith(oneBitmask));
+    }
+
+    [Fact]
+    public void HasCommonBitsWithShouldWorkCorrectlyBitmasksOfDifferentLength()
+    {
+        var bitmask = GenerateBitmask();
+        var zeroBitmask = new Bitmask(RandomBitmaskLength(), initializeWithZeros: true);
+        var oneBitmask = new Bitmask(RandomBitmaskLength(), initializeWithZeros: false);
+        
+        Assert.False(bitmask.HasCommonSetBitsWith(zeroBitmask));
+        Assert.True(bitmask.HasCommonSetBitsWith(oneBitmask));
     }
 
     [Fact]

--- a/TryAtSoftware.Extensions.Collections.Tests/BitmaskTests.cs
+++ b/TryAtSoftware.Extensions.Collections.Tests/BitmaskTests.cs
@@ -3,47 +3,9 @@
 using System;
 using TryAtSoftware.Randomizer.Core.Helpers;
 using Xunit;
-using Xunit.Abstractions;
 
 public class BitmaskTests
 {
-    private readonly ITestOutputHelper _testOutputHelper;
-
-    public BitmaskTests(ITestOutputHelper testOutputHelper)
-    {
-        this._testOutputHelper = testOutputHelper ?? throw new ArgumentNullException(nameof(testOutputHelper));
-    }
-
-    [Fact]
-    public void Test()
-    {
-        Bitmask bitmask1 = new Bitmask(8, initializeWithZeros: true);
-        Bitmask bitmask2 = new Bitmask(8, initializeWithZeros: true);
-        Bitmask bitmask3 = new Bitmask(8, initializeWithZeros: true);
-        Bitmask bitmask4 = new Bitmask(8, initializeWithZeros: true);
-
-        // Set the corresponding bits so the first bitmask looks like this: 11010100
-        bitmask1.Set(0); bitmask1.Set(1); bitmask1.Set(3); bitmask1.Set(5);
-
-        // Set the corresponding bits so the second bitmask looks like this: 01100101
-        bitmask2.Set(1); bitmask2.Set(2); bitmask2.Set(5); bitmask2.Set(7);
-        
-        // Set the corresponding bits so the third bitmask looks like this: 01001011
-        bitmask3.Set(1); bitmask3.Set(4); bitmask3.Set(6); bitmask3.Set(7);
-        
-        // Set the corresponding bits so the fourth bitmask looks like this: 11000010
-        bitmask4.Set(0); bitmask4.Set(1); bitmask4.Set(6);
-
-        bitmask1.InPlaceAnd(bitmask2); // bitmask1: 01000100; bitmask2 remains unchanged
-        bitmask2.InPlaceOr(bitmask3); // bitmask2: 01101111; bitmask3 remains unchanged
-        bitmask3.InPlaceXor(bitmask4); // bitmask3: 10001001; bitmask4 remains unchanged
-        
-        this._testOutputHelper.WriteLine(bitmask1.ToString());
-        this._testOutputHelper.WriteLine(bitmask2.ToString());
-        this._testOutputHelper.WriteLine(bitmask3.ToString());
-        this._testOutputHelper.WriteLine(bitmask4.ToString());
-    }
-
     [Fact]
     public void BitsShouldBeIndexedSuccessfully()
     {

--- a/TryAtSoftware.Extensions.Collections.md
+++ b/TryAtSoftware.Extensions.Collections.md
@@ -276,7 +276,7 @@ int unsetBitsCount3 = bitmask.CountUnsetBits(); // 6
 
 #### Check if two bitmasks share some common bits
 
-Of course, for this purpose we could use the bitwise-and operation like this: `(a & b).FindMostSignificantSetBit() != -1`, or `(a & b).FindLeastSignificantSetBit() != -1`, or `(a & b).CountSetBits() > 0`.
+Of course, for this purpose we could use the bitwise-and operation like this: `(a & b).FindMostSignificantSetBit() != -1`, or `(a & b).FindLeastSignificantSetBit() != -1`, or `(a & b).CountSetBits() > 0`, etc.
 However, all of these solutions have on major downside - either we have to sacrifice one of the bitmasks (by using in-place bitwise operations), or we must allocate additional memory.
 
 Conveniently enough, the `HasCommonSetBitsWith` method solves these two problems.

--- a/TryAtSoftware.Extensions.Collections.md
+++ b/TryAtSoftware.Extensions.Collections.md
@@ -274,6 +274,34 @@ int setBitsCount3 = bitmask.CountSetBits(); // 2
 int unsetBitsCount3 = bitmask.CountUnsetBits(); // 6
 ```
 
+#### Check if two bitmasks share some common bits
+
+Of course, for this purpose we could use the bitwise-and operation like this: `(a & b).FindMostSignificantSetBit() != -1`, or `(a & b).FindLeastSignificantSetBit() != -1`, or `(a & b).CountSetBits() > 0`.
+However, all of these solutions have on major downside - either we have to sacrifice one of the bitmasks (by using in-place bitwise operations), or we must allocate additional memory.
+
+Conveniently enough, the `HasCommonSetBitsWith` method solves these two problems.
+
+> This method is commutative, i.e. `a.HasCommonSetBitsWith(b)` will **always** be equivalent to `b.HasCommonSetBitsWith(a)`.
+
+```C#
+Bitmask bitmask1 = new Bitmask(8, initializeWithZeros: true);
+Bitmask bitmask2 = new Bitmask(8, initializeWithZeros: true);
+Bitmask bitmask3 = new Bitmask(8, initializeWithZeros: true);
+
+// Set the corresponding bits so the first bitmask looks like this: 10101010
+bitmask1.Set(0); bitmask1.Set(2); bitmask1.Set(4); bitmask1.Set(6);
+
+// Set the corresponding bits so the second bitmask looks like this: 00001111
+bitmask2.Set(4); bitmask2.Set(5); bitmask2.Set(6); bitmask2.Set(7);
+
+// Set the corresponding bits so the third bitmask looks like this: 11110000
+bitmask3.Set(0); bitmask3.Set(1); bitmask3.Set(2); bitmask3.Set(3);
+
+var result1 = bitmask1.HasCommonSetBitsWith(bitmask2); // True
+var result2 = bitmask1.HasCommonSetBitsWith(bitmask3); // True
+var result3 = bitmask2.HasCommonSetBitsWith(bitmask3); // False
+```
+
 ## Collection extensions
 
 ### `OrEmptyIfNull`

--- a/TryAtSoftware.Extensions.Collections/Bitmask.cs
+++ b/TryAtSoftware.Extensions.Collections/Bitmask.cs
@@ -141,6 +141,25 @@ public class Bitmask
     public int CountUnsetBits() => this.Length - this.CountSetBits();
 
     /// <summary>
+    /// Use this method to determine if there exists at least one position for which both bits from the current bitmask instance and from the provided <paramref name="other"/> instance are set. 
+    /// </summary>
+    /// <param name="other">The other <see cref="Bitmask"/> instance.</param>
+    /// <returns>Returns <c>true</c> if there is a position at which the bits from both bitmasks are set. Else, returns <c>false</c>.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if the provided <paramref name="other"/> is <c>null</c>.</exception>
+    public bool HasCommonSetBitsWith(Bitmask other)
+    {
+        if (other is null) throw new ArgumentNullException(nameof(other));
+
+        var minSegmentsCount = Math.Min(this.SegmentsCount, other.SegmentsCount);
+        for (var i = 0; i < minSegmentsCount; i++)
+        {
+            if ((this.GetSegment(i) | other.GetSegment(i)) != ZeroSegment) return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Computes bitwise-and in-place with another two <see cref="Bitmask"/> instance.
     /// </summary>
     /// <param name="other">The other bitmask.</param>

--- a/TryAtSoftware.Extensions.Collections/Bitmask.cs
+++ b/TryAtSoftware.Extensions.Collections/Bitmask.cs
@@ -152,9 +152,7 @@ public class Bitmask
 
         var minSegmentsCount = Math.Min(this.SegmentsCount, other.SegmentsCount);
         for (var i = 0; i < minSegmentsCount; i++)
-        {
-            if ((this.GetSegment(i) | other.GetSegment(i)) != ZeroSegment) return true;
-        }
+            if ((this.GetSegment(i) & other.GetSegment(i)) != ZeroSegment) return true;
 
         return false;
     }


### PR DESCRIPTION
## Pull Request Description 

Implemented, documented and tested the new `HasCommonSetBitsWith` method for the `Bitmask` class.

## Motivation and Context

We need additional efficiency when determining if there exists at least one position for which both bits from two bitmask instances are set.

## Checklist

- [x] I have tested these changes thoroughly.
- [x] I have added/updated relevant documentation.
- [x] My code follows the project's coding guidelines.
- [x] I have performed a self-review of my changes.
- [x] My changes are backwards compatible.
