### PR TITLE
Reworked in-place bitwise operations

### DIFF
--- a/TryAtSoftware.Extensions.Collections.Tests/BitmaskTests.cs
+++ b/TryAtSoftware.Extensions.Collections.Tests/BitmaskTests.cs
@@ -482,7 +482,7 @@ public class BitmaskTests
         var copyConstituent2 = new Bitmask(length, initializeWithZeros: true);
         for (var i = 0; i < length; i++)
         {
-            var expectedBit = getExpectedBit(originalBitmask.IsSet(i), constituent1.IsSet(i));
+            var expectedBit = getExpectedBit(constituent1.IsSet(i), constituent2.IsSet(i));
             if (expectedBit) expected.Set(i);
 
             if (constituent1.IsSet(i)) copyConstituent1.Set(i);

--- a/TryAtSoftware.Extensions.Collections.md
+++ b/TryAtSoftware.Extensions.Collections.md
@@ -170,9 +170,10 @@ bitmask3.Set(1); bitmask3.Set(4); bitmask3.Set(6); bitmask3.Set(7);
 // Set the corresponding bits so the fourth bitmask looks like this: 11000010
 bitmask4.Set(0); bitmask4.Set(1); bitmask4.Set(6);
 
-bitmask1.InPlaceAnd(bitmask2); // bitmask1 changes to 01000100; bitmask2 remains unchanged
-bitmask2.InPlaceOr(bitmask3); // bitmask2 changes to 01101111; bitmask3 remains unchanged
-bitmask3.InPlaceXor(bitmask4); // bitmask3 changes to 10001001; bitmask4 remains unchanged
+Bitmask result = new Bitmask(8, initializeWithZeros: true);
+result.InPlaceAnd(bitmask1, bitmask2); // `result` changes to 01000100; `bitmask1` and `bitmask2` remains unchanged
+result.InPlaceOr(bitmask2, bitmask3); // `result` changes to 01101111; `bitmask2` and `bitmask3` remains unchanged
+result.InPlaceXor(bitmask3, bitmask4); // `result` changes to 10001001; `bitmask3` and `bitmask4` remains unchanged
 ```
 
 #### Find the position of the most significant set bit

--- a/TryAtSoftware.Extensions.Collections/Bitmask.cs
+++ b/TryAtSoftware.Extensions.Collections/Bitmask.cs
@@ -158,22 +158,25 @@ public class Bitmask
     }
 
     /// <summary>
-    /// Computes bitwise-and in-place with another two <see cref="Bitmask"/> instance.
+    /// Assigns to the current instance the result of executing bitwise-and of two other bitmasks.
     /// </summary>
-    /// <param name="other">The other bitmask.</param>
-    public void InPlaceAnd(Bitmask other) => this.ExecuteInPlaceBitwiseOperation(other, BitwiseAnd);
+    /// <param name="left">The first bitmask.</param>
+    /// <param name="right">The second bitmask.</param>
+    public void InPlaceAnd(Bitmask left, Bitmask right) => this.ExecuteInPlaceBitwiseOperation(left, right, BitwiseAnd);
 
     /// <summary>
-    /// Computes bitwise-or in-place with another two <see cref="Bitmask"/> instance.
+    /// Assigns to the current instance the result of executing bitwise-or of two other bitmasks.
     /// </summary>
-    /// <param name="other">The other bitmask.</param>
-    public void InPlaceOr(Bitmask other) => this.ExecuteInPlaceBitwiseOperation(other, BitwiseOr);
+    /// <param name="left">The first bitmask.</param>
+    /// <param name="right">The second bitmask.</param>
+    public void InPlaceOr(Bitmask left, Bitmask right) => this.ExecuteInPlaceBitwiseOperation(left, right, BitwiseOr);
 
     /// <summary>
-    /// Computes exclusive-or in-place with another two <see cref="Bitmask"/> instance.
+    /// Assigns to the current instance the result of executing exclusive-or of two other bitmasks.
     /// </summary>
-    /// <param name="other">The other bitmask.</param>
-    public void InPlaceXor(Bitmask other) => this.ExecuteInPlaceBitwiseOperation(other, BitwiseXor);
+    /// <param name="left">The first bitmask.</param>
+    /// <param name="right">The second bitmask.</param>
+    public void InPlaceXor(Bitmask left, Bitmask right) => this.ExecuteInPlaceBitwiseOperation(left, right, BitwiseXor);
 
     /// <inheritdoc />
     public override string ToString()
@@ -312,15 +315,16 @@ public class Bitmask
         return result;
     }
 
-    private void ExecuteInPlaceBitwiseOperation(Bitmask other, Func<ulong, ulong, ulong> operation)
+    private void ExecuteInPlaceBitwiseOperation(Bitmask a, Bitmask b, Func<ulong, ulong, ulong> operation)
     {
-        if (other is null) throw new ArgumentNullException(nameof(other));
-        if (this.Length != other.Length) throw new InvalidOperationException("Both bitmask instances must have the same length in order to execute an in-place bitwise operation.");
+        if (a is null) throw new ArgumentNullException(nameof(a));
+        if (b is null) throw new ArgumentNullException(nameof(b));
+        if (this.Length != a.Length || this.Length != b.Length) throw new InvalidOperationException("Both bitmask instances must have the same length in order to execute an in-place bitwise operation.");
         
         for (var i = 0; i < this.SegmentsCount; i++)
         {
-            var left = this.GetSegment(i);
-            var right = other.GetSegment(i);
+            var left = a.GetSegment(i);
+            var right = b.GetSegment(i);
 
             this.SetSegment(i, operation(left, right));
         }


### PR DESCRIPTION
## Pull Request Description 

The in-place bitwise operations now accept two constituents (no longer the current instance is assumed to be one of them).
The changes introduced by this PR are not backwards compatible, however, the new changes are still in alpha.

## Motivation and Context

It appears that the existing implementation is rather limiting and can cause performance downgrades.

## Checklist

- [x] I have tested these changes thoroughly.
- [ ] I have added/updated relevant documentation.
- [x] My code follows the project's coding guidelines.
- [ ] I have performed a self-review of my changes.
- [ ] My changes are backwards compatible.
