### PR TITLE
Upgraded internal references towards `TryAtSoftware.Extensions.Reflection`

### DIFF
--- a/TryAtSoftware.Extensions.Collections.Tests/TryAtSoftware.Extensions.Collections.Tests.csproj
+++ b/TryAtSoftware.Extensions.Collections.Tests/TryAtSoftware.Extensions.Collections.Tests.csproj
@@ -15,7 +15,7 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-        <PackageReference Include="SonarAnalyzer.CSharp" Version="9.5.0.73987">
+        <PackageReference Include="SonarAnalyzer.CSharp" Version="9.11.0.78383">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/TryAtSoftware.Extensions.Collections/TryAtSoftware.Extensions.Collections.csproj
+++ b/TryAtSoftware.Extensions.Collections/TryAtSoftware.Extensions.Collections.csproj
@@ -18,7 +18,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="SonarAnalyzer.CSharp" Version="9.5.0.73987" PrivateAssets="all" />
+        <PackageReference Include="SonarAnalyzer.CSharp" Version="9.11.0.78383" PrivateAssets="all" />
     </ItemGroup>
 
     <ItemGroup>

--- a/TryAtSoftware.Extensions.DependencyInjection.Standard.Tests/TryAtSoftware.Extensions.DependencyInjection.Standard.Tests.csproj
+++ b/TryAtSoftware.Extensions.DependencyInjection.Standard.Tests/TryAtSoftware.Extensions.DependencyInjection.Standard.Tests.csproj
@@ -17,7 +17,7 @@
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
         <PackageReference Include="Moq" Version="4.18.4" />
-        <PackageReference Include="SonarAnalyzer.CSharp" Version="9.5.0.73987">
+        <PackageReference Include="SonarAnalyzer.CSharp" Version="9.11.0.78383">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/TryAtSoftware.Extensions.DependencyInjection.Standard/TryAtSoftware.Extensions.DependencyInjection.Standard.csproj
+++ b/TryAtSoftware.Extensions.DependencyInjection.Standard/TryAtSoftware.Extensions.DependencyInjection.Standard.csproj
@@ -19,7 +19,7 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.1" />
-      <PackageReference Include="SonarAnalyzer.CSharp" Version="9.5.0.73987">
+      <PackageReference Include="SonarAnalyzer.CSharp" Version="9.11.0.78383">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>

--- a/TryAtSoftware.Extensions.DependencyInjection.Tests/TryAtSoftware.Extensions.DependencyInjection.Tests.csproj
+++ b/TryAtSoftware.Extensions.DependencyInjection.Tests/TryAtSoftware.Extensions.DependencyInjection.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 
@@ -16,7 +16,7 @@
         </PackageReference>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
         <PackageReference Include="Moq" Version="4.18.4" />
-        <PackageReference Include="SonarAnalyzer.CSharp" Version="9.5.0.73987">
+        <PackageReference Include="SonarAnalyzer.CSharp" Version="9.11.0.78383">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/TryAtSoftware.Extensions.DependencyInjection/TryAtSoftware.Extensions.DependencyInjection.csproj
+++ b/TryAtSoftware.Extensions.DependencyInjection/TryAtSoftware.Extensions.DependencyInjection.csproj
@@ -6,7 +6,7 @@
         <Nullable>enable</Nullable>
 
         <PackageId>TryAtSoftware.Extensions.DependencyInjection</PackageId>
-        <Version>1.1.2-alpha.1</Version>
+        <Version>1.1.2-alpha.2</Version>
         <Authors>Tony Troeff</Authors>
         <RepositoryUrl>https://github.com/TryAtSoftware/Extensions</RepositoryUrl>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -18,12 +18,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="SonarAnalyzer.CSharp" Version="9.5.0.73987">
+      <PackageReference Include="SonarAnalyzer.CSharp" Version="9.11.0.78383">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
       <PackageReference Include="TryAtSoftware.Extensions.Collections" Version="1.0.0" />
-      <PackageReference Include="TryAtSoftware.Extensions.Reflection" Version="1.1.1" />
+      <PackageReference Include="TryAtSoftware.Extensions.Reflection" Version="1.1.2-alpha.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/TryAtSoftware.Extensions.Reflection.Tests/TryAtSoftware.Extensions.Reflection.Tests.csproj
+++ b/TryAtSoftware.Extensions.Reflection.Tests/TryAtSoftware.Extensions.Reflection.Tests.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="coverlet.msbuild" Version="6.0.0" PrivateAssets="all" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
         <PackageReference Include="Moq" Version="4.18.4" />
-        <PackageReference Include="SonarAnalyzer.CSharp" Version="9.5.0.73987" PrivateAssets="all" />
+        <PackageReference Include="SonarAnalyzer.CSharp" Version="9.11.0.78383" PrivateAssets="all" />
         <PackageReference Include="TryAtSoftware.Randomizer" Version="2.0.2-alpha.1" />
         <PackageReference Include="xunit" Version="2.5.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" PrivateAssets="all" />

--- a/TryAtSoftware.Extensions.Reflection/TryAtSoftware.Extensions.Reflection.csproj
+++ b/TryAtSoftware.Extensions.Reflection/TryAtSoftware.Extensions.Reflection.csproj
@@ -18,7 +18,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="SonarAnalyzer.CSharp" Version="9.5.0.73987" PrivateAssets="all" />
+        <PackageReference Include="SonarAnalyzer.CSharp" Version="9.11.0.78383" PrivateAssets="all" />
         <PackageReference Include="TryAtSoftware.Extensions.Collections" Version="1.0.0" />
     </ItemGroup>
 


### PR DESCRIPTION
## Pull Request Description 

Upgraded all `SonarAnalyzer.CSharp` references. Upgraded all internal `TryAtSoftware.Extensions.Reflection` references to latest pre-release.
This PR will introduce a new pre-release for the `TryAtSoftware.Extensions.DependencyInjection` package.

## Motivation and Context

We need the latest fixes in `TryAtSoftware.Extensions.Reflection` into the `TryAtSoftware.Extensions.DependencyInjection.*` packages