### PR TITLE
Updated development packages to latest

### DIFF
--- a/TryAtSoftware.Extensions.Collections.Tests/TryAtSoftware.Extensions.Collections.Tests.csproj
+++ b/TryAtSoftware.Extensions.Collections.Tests/TryAtSoftware.Extensions.Collections.Tests.csproj
@@ -14,22 +14,22 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3"/>
-        <PackageReference Include="SonarAnalyzer.CSharp" Version="9.11.0.78383">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+        <PackageReference Include="SonarAnalyzer.CSharp" Version="9.12.0.78982">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="TryAtSoftware.Randomizer" Version="2.0.2-alpha.1"/>
-        <PackageReference Include="xunit" Version="2.5.0"/>
+        <PackageReference Include="xunit" Version="2.6.1" />
         <PackageReference Include="coverlet.collector" Version="6.0.0" PrivateAssets="all"/>
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" PrivateAssets="all"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" PrivateAssets="all" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" PrivateAssets="all"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" PrivateAssets="all" />
     </ItemGroup>
 
     <ItemGroup>

--- a/TryAtSoftware.Extensions.Collections.Tests/TryAtSoftware.Extensions.Collections.Tests.csproj
+++ b/TryAtSoftware.Extensions.Collections.Tests/TryAtSoftware.Extensions.Collections.Tests.csproj
@@ -25,10 +25,10 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" PrivateAssets="all" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" PrivateAssets="all" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net7.0' or '$(TargetFramework)' == 'net8.0'">
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" PrivateAssets="all" />
     </ItemGroup>
 

--- a/TryAtSoftware.Extensions.Collections/TryAtSoftware.Extensions.Collections.csproj
+++ b/TryAtSoftware.Extensions.Collections/TryAtSoftware.Extensions.Collections.csproj
@@ -18,7 +18,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="SonarAnalyzer.CSharp" Version="9.11.0.78383" PrivateAssets="all"/>
+        <PackageReference Include="SonarAnalyzer.CSharp" Version="9.12.0.78982" PrivateAssets="all" />
     </ItemGroup>
 
     <ItemGroup>

--- a/TryAtSoftware.Extensions.DependencyInjection.Standard.Tests/TryAtSoftware.Extensions.DependencyInjection.Standard.Tests.csproj
+++ b/TryAtSoftware.Extensions.DependencyInjection.Standard.Tests/TryAtSoftware.Extensions.DependencyInjection.Standard.Tests.csproj
@@ -15,15 +15,15 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
         <PackageReference Include="NSubstitute" Version="5.1.0" />
-        <PackageReference Include="SonarAnalyzer.CSharp" Version="9.11.0.78383">
+        <PackageReference Include="SonarAnalyzer.CSharp" Version="9.12.0.78982">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="TryAtSoftware.Randomizer" Version="2.0.2-alpha.1" />
-        <PackageReference Include="xunit" Version="2.5.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+        <PackageReference Include="xunit" Version="2.6.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/TryAtSoftware.Extensions.DependencyInjection.Standard/TryAtSoftware.Extensions.DependencyInjection.Standard.csproj
+++ b/TryAtSoftware.Extensions.DependencyInjection.Standard/TryAtSoftware.Extensions.DependencyInjection.Standard.csproj
@@ -18,7 +18,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="SonarAnalyzer.CSharp" Version="9.11.0.78383">
+        <PackageReference Include="SonarAnalyzer.CSharp" Version="9.12.0.78982">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/TryAtSoftware.Extensions.DependencyInjection.Tests/TryAtSoftware.Extensions.DependencyInjection.Tests.csproj
+++ b/TryAtSoftware.Extensions.DependencyInjection.Tests/TryAtSoftware.Extensions.DependencyInjection.Tests.csproj
@@ -14,15 +14,15 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
         <PackageReference Include="NSubstitute" Version="5.1.0" />
-        <PackageReference Include="SonarAnalyzer.CSharp" Version="9.11.0.78383">
+        <PackageReference Include="SonarAnalyzer.CSharp" Version="9.12.0.78982">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="TryAtSoftware.Randomizer" Version="2.0.2-alpha.1"/>
-        <PackageReference Include="xunit" Version="2.5.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+        <PackageReference Include="xunit" Version="2.6.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/TryAtSoftware.Extensions.DependencyInjection/TryAtSoftware.Extensions.DependencyInjection.csproj
+++ b/TryAtSoftware.Extensions.DependencyInjection/TryAtSoftware.Extensions.DependencyInjection.csproj
@@ -18,7 +18,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="SonarAnalyzer.CSharp" Version="9.11.0.78383">
+        <PackageReference Include="SonarAnalyzer.CSharp" Version="9.12.0.78982">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/TryAtSoftware.Extensions.Reflection.Benchmark/TryAtSoftware.Extensions.Reflection.Benchmark.csproj
+++ b/TryAtSoftware.Extensions.Reflection.Benchmark/TryAtSoftware.Extensions.Reflection.Benchmark.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="BenchmarkDotNet" Version="0.13.6" />
+      <PackageReference Include="BenchmarkDotNet" Version="0.13.10" />
     </ItemGroup>
 
     <ItemGroup>

--- a/TryAtSoftware.Extensions.Reflection.Tests/TryAtSoftware.Extensions.Reflection.Tests.csproj
+++ b/TryAtSoftware.Extensions.Reflection.Tests/TryAtSoftware.Extensions.Reflection.Tests.csproj
@@ -10,12 +10,12 @@
 
     <ItemGroup>
         <PackageReference Include="coverlet.msbuild" Version="6.0.0" PrivateAssets="all"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
         <PackageReference Include="Moq" Version="4.18.4"/>
-        <PackageReference Include="SonarAnalyzer.CSharp" Version="9.11.0.78383" PrivateAssets="all"/>
+        <PackageReference Include="SonarAnalyzer.CSharp" Version="9.12.0.78982" PrivateAssets="all" />
         <PackageReference Include="TryAtSoftware.Randomizer" Version="2.0.2-alpha.1"/>
-        <PackageReference Include="xunit" Version="2.5.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" PrivateAssets="all"/>
+        <PackageReference Include="xunit" Version="2.6.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" PrivateAssets="all" />
         <PackageReference Include="coverlet.collector" Version="6.0.0" PrivateAssets="all"/>
     </ItemGroup>
 

--- a/TryAtSoftware.Extensions.Reflection/TryAtSoftware.Extensions.Reflection.csproj
+++ b/TryAtSoftware.Extensions.Reflection/TryAtSoftware.Extensions.Reflection.csproj
@@ -18,7 +18,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="SonarAnalyzer.CSharp" Version="9.11.0.78383" PrivateAssets="all"/>
+        <PackageReference Include="SonarAnalyzer.CSharp" Version="9.12.0.78982" PrivateAssets="all" />
         <PackageReference Include="TryAtSoftware.Extensions.Collections" Version="1.0.0"/>
     </ItemGroup>
 


### PR DESCRIPTION
## Pull Request Description 

Updated the `SonarAnalyzer.CSharp`, `BenchmarkDotNet`, `Microsoft.NET.Test.Sdk`, `xunit` and `xunit.runner.visualstudio` packages.

## Motivation and Context

After the release of .NET 8, tests targeting this new version were not executed in the automated build pipeline.