### PR TITLE
Added collection extension methods for `IList<T>`

### DIFF
--- a/TryAtSoftware.Extensions.Collections.Tests/CollectionExtensionsTests.cs
+++ b/TryAtSoftware.Extensions.Collections.Tests/CollectionExtensionsTests.cs
@@ -10,18 +10,25 @@ public class CollectionExtensionsTests
     [Fact]
     public void OrEmptyIfNullShouldReturnTheSameCollectionIfItIsNotNull()
     {
-        var collection = TestsHelper.GetStandardCollection();
-        var result = collection.OrEmptyIfNull();
-        Assert.NotNull(result);
-        Assert.Same(collection, result);
+        var collection = TestsHelper.GetStandardCollection().ToArray();
+        var result1 = ((IEnumerable<int>) collection).OrEmptyIfNull();
+        var result2 = ((IList<int>) collection).OrEmptyIfNull();
+
+        Assert.Same(collection, result1);
+        Assert.Same(collection, result2);
     }
 
     [Fact]
     public void OrEmptyIfNullShouldReturnEmptyCollectionIfNullIsPassed()
     {
-        var result = ((IEnumerable<object>?)null).OrEmptyIfNull();
-        Assert.NotNull(result);
-        Assert.Empty(result);
+        var result1 = ((IEnumerable<object>?)null).OrEmptyIfNull();
+        var result2 = ((IList<object>?)null).OrEmptyIfNull();
+        
+        Assert.NotNull(result1);
+        Assert.Empty(result1);
+        
+        Assert.NotNull(result2);
+        Assert.Empty(result2);
     }
 
     [Fact]
@@ -123,7 +130,7 @@ public class CollectionExtensionsTests
     }
 
     [Fact]
-    public void SetUnionShouldHandleNull()
+    public void UnionShouldHandleNull()
     {
         var result = ((IEnumerable<HashSet<object>>?)null).Union();
         Assert.NotNull(result);
@@ -131,7 +138,7 @@ public class CollectionExtensionsTests
     }
 
     [Fact]
-    public void SetUnionShouldWorkCorrectly()
+    public void UnionShouldWorkCorrectly()
     {
         var standardCollection = TestsHelper.GetStandardCollection().ToArray();
         
@@ -146,18 +153,25 @@ public class CollectionExtensionsTests
     [Fact]
     public void AsReadOnlyCollectionShouldHandleNull()
     {
-        var result = ((IEnumerable<object>?)null).AsReadOnlyCollection();
-        Assert.NotNull(result);
-        Assert.Empty(result);
+        var result1 = ((IEnumerable<object>?)null).AsReadOnlyCollection();
+        var result2 = ((IList<object>?)null).AsReadOnlyCollection();
+
+        Assert.NotNull(result1);
+        Assert.Empty(result1);
+        
+        Assert.NotNull(result2);
+        Assert.Empty(result2);
     }
 
     [Fact]
     public void AsReadOnlyCollectionShouldWorkCorrectly()
     {
         var standardCollection = TestsHelper.GetStandardCollection().ToArray();
-        var readonlyCollection = standardCollection.AsReadOnlyCollection();
 
-        Assert.Equal(standardCollection, readonlyCollection);
+        var readonlyCollection1 = ((IEnumerable<int>) standardCollection).AsReadOnlyCollection();
+        var readonlyCollection2 = ((IList<int>) standardCollection).AsReadOnlyCollection();
+        Assert.Equal(standardCollection, readonlyCollection1);
+        Assert.Equal(standardCollection, readonlyCollection2);
     }
 
     public static IEnumerable<object?[]> GetConcatenateWithTestData()

--- a/TryAtSoftware.Extensions.Collections/CollectionExtensions.cs
+++ b/TryAtSoftware.Extensions.Collections/CollectionExtensions.cs
@@ -2,6 +2,7 @@ namespace TryAtSoftware.Extensions.Collections;
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 
 /// <summary>
@@ -31,7 +32,15 @@ public static class CollectionExtensions
     /// <typeparam name="T">The type of elements in the collection.</typeparam>
     /// <param name="collection">The extended <see cref="IEnumerable{T}"/> instance.</param>
     /// <returns>Returns the same collection if it was not null. Else, returns an empty enumerable.</returns>
-    public static IEnumerable<T> OrEmptyIfNull<T>(this IEnumerable<T>? collection) => collection ?? Enumerable.Empty<T>();
+    public static IEnumerable<T> OrEmptyIfNull<T>(this IEnumerable<T>? collection) => collection ?? [];
+
+    /// <summary>
+    /// This method will give you an empty enumerable instance if the extended <paramref name="collection"/> is null.
+    /// </summary>
+    /// <typeparam name="T">The type of elements in the collection.</typeparam>
+    /// <param name="collection">The extended <see cref="IList{T}"/> instance.</param>
+    /// <returns>Returns the same collection if it was not null. Else, returns an empty enumerable.</returns>
+    public static IList<T> OrEmptyIfNull<T>(this IList<T>? collection) => collection ?? new List<T>(capacity: 0);
 
     /// <summary>
     /// Use this method to filter out all null values from the extended <paramref name="collection"/>.
@@ -111,5 +120,13 @@ public static class CollectionExtensions
     /// <typeparam name="T">The type of elements in the collection.</typeparam>
     /// <param name="collection">The extended <see cref="IEnumerable{T}"/> instance.</param>
     /// <returns>Returns an <see cref="IReadOnlyCollection{T}"/> containing all elements from the extended <paramref name="collection"/> in the same order.</returns>
-    public static IReadOnlyCollection<T> AsReadOnlyCollection<T>(this IEnumerable<T>? collection) => collection.OrEmptyIfNull().ToList().AsReadOnly();
+    public static IReadOnlyCollection<T> AsReadOnlyCollection<T>(this IEnumerable<T>? collection) => collection.OrEmptyIfNull().ToList().AsReadOnlyCollection();
+
+    /// <summary>
+    /// Use this method to construct an <see cref="IReadOnlyCollection{T}"/> instance from the extended <paramref name="list"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of elements in the collection.</typeparam>
+    /// <param name="list">The extended <see cref="IList{T}"/> instance.</param>
+    /// <returns>Returns an <see cref="IReadOnlyCollection{T}"/> containing all elements from the extended <paramref name="list"/> in the same order.</returns>
+    public static IReadOnlyCollection<T> AsReadOnlyCollection<T>(this IList<T>? list) => new ReadOnlyCollection<T>(list.OrEmptyIfNull());
 }


### PR DESCRIPTION
## Pull Request Description 

Added a new overload for the `.OrEmptyIfNull()` and `.AsReadOnlyCollection()` methods that targets `IList<T>` instances.

## Motivation and Context

The `.AsReadOnlyCollection()` method includes a `.ToList()` call. It will be unnecessary if we already have a list instance.

## Checklist

- [x] I have tested these changes thoroughly.
- [x] I have added/updated relevant documentation.
- [x] My code follows the project's coding guidelines.
- [x] I have performed a self-review of my changes.
- [x] My changes are backwards compatible.
