### PR TITLE
Increased the `TryAtSoftware.Extensions.DependencyInjection.Standard` package version to 1.2.0-alpha.1

### DIFF
--- a/TryAtSoftware.Extensions.DependencyInjection.Standard/TryAtSoftware.Extensions.DependencyInjection.Standard.csproj
+++ b/TryAtSoftware.Extensions.DependencyInjection.Standard/TryAtSoftware.Extensions.DependencyInjection.Standard.csproj
@@ -6,7 +6,7 @@
         <Nullable>enable</Nullable>
 
         <PackageId>TryAtSoftware.Extensions.DependencyInjection.Standard</PackageId>
-        <Version>1.1.2</Version>
+        <Version>1.2.0-alpha.1</Version>
         <Authors>Tony Troeff</Authors>
         <RepositoryUrl>https://github.com/TryAtSoftware/Extensions</RepositoryUrl>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
This PR introduces a pre-release for a new minor version of `TryAtSoftware.Extensions.DependencyInjection.Standard` package.