### PR TITLE
Automatically register open generic services into standard DI containers

### DIFF
--- a/TryAtSoftware.Extensions.DependencyInjection.Standard.Tests/ServiceConfigurationAttributeTests.cs
+++ b/TryAtSoftware.Extensions.DependencyInjection.Standard.Tests/ServiceConfigurationAttributeTests.cs
@@ -31,7 +31,7 @@ public class ServiceConfigurationAttributeTests
         var attribute = new ServiceConfigurationAttribute();
         Assert.Null(attribute.Key);
     }
-    
+
     [Fact]
     public void ServiceKeyShouldBeSetCorrectly()
     {
@@ -49,5 +49,9 @@ public class ServiceConfigurationAttributeTests
     }
 #endif
 
-    public static IEnumerable<object[]> GetServiceLifetimeData() => Enum.GetValues<ServiceLifetime>().Select(x => new object[] { x });
+    public static TheoryData<ServiceLifetime> GetServiceLifetimeData()
+    {
+        var serviceLifetimeValues = Enum.GetValues<ServiceLifetime>();
+        return new TheoryData<ServiceLifetime>(serviceLifetimeValues);
+    }
 }

--- a/TryAtSoftware.Extensions.DependencyInjection.Standard.Tests/ServiceRegistrarTests.cs
+++ b/TryAtSoftware.Extensions.DependencyInjection.Standard.Tests/ServiceRegistrarTests.cs
@@ -78,10 +78,12 @@ public class ServiceRegistrarTests
     }
 
     /// <remarks>
-    /// For the <paramref name="genericTypesMap"/> parameter, attribute types are followed by the actual generic parameter type.
+    /// For the <paramref name="genericTypesSetup"/> parameter,
+    /// attribute types are followed by the actual generic parameter type.
     /// </remarks>
     [Theory]
     [InlineData(typeof(GenericService<>), new[] { typeof(IGenericInterface<>) }, new[] { typeof(KeyTypeAttribute), typeof(int) })]
+    [InlineData(typeof(GenericService<,>), new[] { typeof(IGenericInterface<,>) }, new[] { typeof(KeyTypeAttribute), typeof(int), typeof(ValueTypeAttribute), typeof(string) })]
     public void GenericServicesShouldBeSuccessfullyRegistered(Type implementationType, Type[] serviceTypes, Type[] genericTypesSetup)
     {
         var genericTypesMatrix = genericTypesSetup.Chunk(2).ToArray();
@@ -170,27 +172,28 @@ public class ServiceRegistrarTests
         return registeredServiceTypes;
     }
 
-    private interface IBaseInterface { }
-    private interface IGenericInterface<T> { }
-    private interface IGenericInterface<T1, T2> { }
-    private interface IImplementedInterface1 : IBaseInterface { }
-    private interface IImplementedInterface2 : IBaseInterface { }
-    private abstract class BaseService : IImplementedInterface1, IImplementedInterface2 { }
+    private interface IBaseInterface;
+    private interface IGenericInterface<T>;
+    private interface IGenericInterface<T1, T2>;
+    private interface IImplementedInterface1 : IBaseInterface;
+    private interface IImplementedInterface2 : IBaseInterface;
+    private abstract class BaseService : IImplementedInterface1, IImplementedInterface2;
 
-    private class Service : BaseService { }
-    [ServiceConfiguration(Lifetime = ServiceLifetime.Transient)] private class TransientService : BaseService { }
-    [ServiceConfiguration(Lifetime = ServiceLifetime.Scoped)] private class ExplicitlyScopedService : BaseService { }
-    [ServiceConfiguration] private class ImplicitlyScopedService : BaseService { }
-    [ServiceConfiguration(Lifetime = ServiceLifetime.Singleton)] private class SingletonService : BaseService { }
+    private class Service : BaseService;
+    [ServiceConfiguration(Lifetime = ServiceLifetime.Transient)] private class TransientService : BaseService;
+    [ServiceConfiguration(Lifetime = ServiceLifetime.Scoped)] private class ExplicitlyScopedService : BaseService;
+    [ServiceConfiguration] private class ImplicitlyScopedService : BaseService;
+    [ServiceConfiguration(Lifetime = ServiceLifetime.Singleton)] private class SingletonService : BaseService;
 
-    [AttributeUsage(AttributeTargets.GenericParameter)] private class KeyTypeAttribute : Attribute { }
-    private class GenericService<[KeyType] TKey> : IGenericInterface<TKey> { }
+    [AttributeUsage(AttributeTargets.GenericParameter)] private class KeyTypeAttribute : Attribute;
+    [AttributeUsage(AttributeTargets.GenericParameter)] private class ValueTypeAttribute : Attribute;
+    [ServiceConfiguration] private class GenericService<[KeyType] TKey> : IGenericInterface<TKey>;
+    [ServiceConfiguration] private class GenericService<[KeyType] TKey, [ValueType] TValue> : IGenericInterface<TKey, TValue>;
 
-    [ServiceConfiguration(OpenGeneric = true)] private class OpenGenericService<T> : IGenericInterface<T>, IGenericInterface<(T First, T Second)> { }
-    [ServiceConfiguration(OpenGeneric = true)] private class OpenGenericService<T1, T2> : IGenericInterface<T1, T2>, IGenericInterface<(T1 First, T2 Second)> { }
+    [ServiceConfiguration(OpenGeneric = true)] private class OpenGenericService<T> : IGenericInterface<T>, IGenericInterface<(T First, T Second)>;
+    [ServiceConfiguration(OpenGeneric = true)] private class OpenGenericService<T1, T2> : IGenericInterface<T1, T2>, IGenericInterface<(T1 First, T2 Second)>;
 
 #if NET8_0_OR_GREATER
-    [ServiceConfiguration(Key = "service_1")]
-    private class KeyedService : BaseService {}
+    [ServiceConfiguration(Key = "service_1")] private class KeyedService : BaseService;
 #endif
 }

--- a/TryAtSoftware.Extensions.DependencyInjection.Standard.Tests/ServiceRegistrarTests.cs
+++ b/TryAtSoftware.Extensions.DependencyInjection.Standard.Tests/ServiceRegistrarTests.cs
@@ -77,26 +77,48 @@ public class ServiceRegistrarTests
         foreach (var i in interfaces) Assert.Contains(i, registeredServiceTypes);
     }
 
-    [Fact]
-    public void GenericServicesShouldBeSuccessfullyRegistered()
+    /// <remarks>
+    /// For the <paramref name="genericTypesMap"/> parameter, attribute types are followed by the actual generic parameter type.
+    /// </remarks>
+    [Theory]
+    [InlineData(typeof(GenericService<>), new[] { typeof(IGenericInterface<>) }, new[] { typeof(KeyTypeAttribute), typeof(int) })]
+    public void GenericServicesShouldBeSuccessfullyRegistered(Type implementationType, Type[] serviceTypes, Type[] genericTypesSetup)
     {
-        var implementationType = typeof(GenericService<>);
-
-        var keyType = typeof(int);
-        var registrationOptions = new RegisterServiceOptions { GenericTypesMap = new Dictionary<Type, Type> { [typeof(KeyTypeAttribute)] = keyType } };
+        var genericTypesMatrix = genericTypesSetup.Chunk(2).ToArray();
+        var registrationOptions = new RegisterServiceOptions { GenericTypesMap = genericTypesMatrix.ToDictionary(x => x[0], x => x[1]) };
         var (serviceCollection, _, registrar) = InstantiateRegistrar();
 
         registrar.Register(implementationType, registrationOptions);
 
-        var interfaces = implementationType.GetInterfaces();
-        Assert.Equal(interfaces.Length + 1, serviceCollection.Count);
+        Assert.Equal(serviceTypes.Length + 1, serviceCollection.Count);
 
-        var genericImplementationType = implementationType.MakeGenericType(keyType);
-        var genericInterfaceType = typeof(IGenericInterface<>).MakeGenericType(keyType);
+        var genericTypeArguments = genericTypesMatrix.Select(x => x[1]).ToArray();
+        var genericImplementationType = implementationType.MakeGenericType(genericTypeArguments);
         var registeredServiceTypes = AssertSuccessfulRegistration(serviceCollection, genericImplementationType, ServiceLifetime.Scoped);
 
         Assert.Contains(genericImplementationType, registeredServiceTypes);
-        Assert.Contains(genericInterfaceType, registeredServiceTypes);
+
+        foreach (var serviceType in serviceTypes)
+        {
+            var genericServiceType = serviceType.MakeGenericType(genericTypeArguments);
+            Assert.Contains(genericServiceType, registeredServiceTypes);
+        }
+    }
+
+    [Theory]
+    [InlineData(typeof(OpenGenericService<>), new[] { typeof(IGenericInterface<>) })]
+    [InlineData(typeof(OpenGenericService<,>), new[] { typeof(IGenericInterface<,>) })]
+    public void OpenGenericServicesShouldBeSuccessfullyRegistered(Type implementationType, Type[] serviceTypes)
+    {
+        var (serviceCollection, _, registrar) = InstantiateRegistrar();
+        registrar.Register(implementationType);
+
+        Assert.Equal(serviceTypes.Length + 1, serviceCollection.Count);
+
+        var registeredServiceTypes = AssertSuccessfulRegistration(serviceCollection, implementationType, ServiceLifetime.Scoped);
+
+        Assert.Contains(implementationType, registeredServiceTypes);
+        foreach (var interfaceType in serviceTypes) Assert.Contains(interfaceType, registeredServiceTypes);
     }
 
     private static (IServiceCollection Services, IHierarchyScanner HierarchyScanner, IServiceRegistrar Registrar) InstantiateRegistrar()
@@ -149,7 +171,8 @@ public class ServiceRegistrarTests
     }
 
     private interface IBaseInterface { }
-    private interface IGenericInterface<TKey> { }
+    private interface IGenericInterface<T> { }
+    private interface IGenericInterface<T1, T2> { }
     private interface IImplementedInterface1 : IBaseInterface { }
     private interface IImplementedInterface2 : IBaseInterface { }
     private abstract class BaseService : IImplementedInterface1, IImplementedInterface2 { }
@@ -162,6 +185,9 @@ public class ServiceRegistrarTests
 
     [AttributeUsage(AttributeTargets.GenericParameter)] private class KeyTypeAttribute : Attribute { }
     private class GenericService<[KeyType] TKey> : IGenericInterface<TKey> { }
+
+    [ServiceConfiguration(OpenGeneric = true)] private class OpenGenericService<T> : IGenericInterface<T>, IGenericInterface<(T First, T Second)> { }
+    [ServiceConfiguration(OpenGeneric = true)] private class OpenGenericService<T1, T2> : IGenericInterface<T1, T2>, IGenericInterface<(T1 First, T2 Second)> { }
 
 #if NET8_0_OR_GREATER
     [ServiceConfiguration(Key = "service_1")]

--- a/TryAtSoftware.Extensions.DependencyInjection.Standard.Tests/ServiceRegistrarTests.cs
+++ b/TryAtSoftware.Extensions.DependencyInjection.Standard.Tests/ServiceRegistrarTests.cs
@@ -78,8 +78,8 @@ public class ServiceRegistrarTests
     }
 
     /// <remarks>
-    /// For the <paramref name="genericTypesSetup"/> parameter,
-    /// attribute types are followed by the actual generic parameter type.
+    /// For the <paramref name="genericTypesSetup"/>,
+    /// every attribute type is immediately followed by the corresponding generic type argument.
     /// </remarks>
     [Theory]
     [InlineData(typeof(GenericService<>), new[] { typeof(IGenericInterface<>) }, new[] { typeof(KeyTypeAttribute), typeof(int) })]

--- a/TryAtSoftware.Extensions.DependencyInjection.Standard.Tests/TryAtSoftware.Extensions.DependencyInjection.Standard.Tests.csproj
+++ b/TryAtSoftware.Extensions.DependencyInjection.Standard.Tests/TryAtSoftware.Extensions.DependencyInjection.Standard.Tests.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <TargetFrameworks>net7.0;net8.0;net9.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
+        <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
 
         <IsPackable>false</IsPackable>

--- a/TryAtSoftware.Extensions.DependencyInjection.Standard/Attributes/ServiceConfigurationAttribute.cs
+++ b/TryAtSoftware.Extensions.DependencyInjection.Standard/Attributes/ServiceConfigurationAttribute.cs
@@ -12,9 +12,9 @@ public class ServiceConfigurationAttribute : Attribute
     private ServiceLifetime _lifetime;
     
     /// <summary>
-    /// Gets a value indicating whether or not a value is set to the <see cref="Lifetime"/> property.
+    /// Gets a value indicating whether a value is set to the <see cref="Lifetime"/> property.
     /// </summary>
-    public bool LifetimeIsSet { get; private set; }
+    internal bool LifetimeIsSet { get; private set; }
 
     /// <summary>
     /// Gets or sets the lifetime of the decorated service.

--- a/TryAtSoftware.Extensions.DependencyInjection.Standard/Attributes/ServiceConfigurationAttribute.cs
+++ b/TryAtSoftware.Extensions.DependencyInjection.Standard/Attributes/ServiceConfigurationAttribute.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.DependencyInjection;
 public class ServiceConfigurationAttribute : Attribute
 {
     private ServiceLifetime _lifetime;
+    private bool _openGeneric;
     
     /// <summary>
     /// Gets a value indicating whether a value is set to the <see cref="Lifetime"/> property.
@@ -28,11 +29,24 @@ public class ServiceConfigurationAttribute : Attribute
             this._lifetime = value;
         }
     }
+    
+    /// <summary>
+    /// Gets a value indicating whether a value is set to the <see cref="OpenGeneric"/> property.
+    /// </summary>
+    internal bool OpenGenericIsSet { get; private set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether the decorated class should be registered as an open generic type within the standard dependency injection container.
     /// </summary>
-    public bool? OpenGeneric { get; set; }
+    public bool OpenGeneric
+    {
+        get => this._openGeneric;
+        set
+        {
+            this.OpenGenericIsSet = true;
+            this._openGeneric = value;
+        }
+    }
 
 #if NET8_0_OR_GREATER
     public string? Key { get; set; }

--- a/TryAtSoftware.Extensions.DependencyInjection.Standard/Attributes/ServiceConfigurationAttribute.cs
+++ b/TryAtSoftware.Extensions.DependencyInjection.Standard/Attributes/ServiceConfigurationAttribute.cs
@@ -29,6 +29,11 @@ public class ServiceConfigurationAttribute : Attribute
         }
     }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether the decorated class should be registered as an open generic type within the standard dependency injection container.
+    /// </summary>
+    public bool? OpenGeneric { get; set; }
+
 #if NET8_0_OR_GREATER
     public string? Key { get; set; }
 #endif

--- a/TryAtSoftware.Extensions.DependencyInjection.Standard/ServiceRegistrar.cs
+++ b/TryAtSoftware.Extensions.DependencyInjection.Standard/ServiceRegistrar.cs
@@ -101,8 +101,8 @@ public class ServiceRegistrar : IServiceRegistrar
     {
         for (var i = configurationAttributes.Length - 1; i >= 0; i--)
         {
-            var openGeneric = configurationAttributes[i].OpenGeneric;
-            if (openGeneric.HasValue) return openGeneric.Value;
+            if (configurationAttributes[i].OpenGenericIsSet)
+                return configurationAttributes[i].OpenGeneric;
         }
 
         return false;

--- a/TryAtSoftware.Extensions.DependencyInjection.Standard/ServiceRegistrar.cs
+++ b/TryAtSoftware.Extensions.DependencyInjection.Standard/ServiceRegistrar.cs
@@ -53,7 +53,7 @@ public class ServiceRegistrar : IServiceRegistrar
         if (ShouldBeRegisteredAsOpenGeneric(configurationAttributes))
         {
             var genericArguments = type.GetGenericArguments();
-            return (type, implementedInterfaces.Where(x => genericArguments.SequenceEqual(x.GenericTypeArguments)));
+            return (type, implementedInterfaces.Where(x => genericArguments.SequenceEqual(x.GenericTypeArguments)).Select(x => x.GetGenericTypeDefinition()));
         }
 
         var genericParametersSetup = ExtractGenericParametersSetup(type, options);

--- a/TryAtSoftware.Extensions.DependencyInjection.Standard/TryAtSoftware.Extensions.DependencyInjection.Standard.csproj
+++ b/TryAtSoftware.Extensions.DependencyInjection.Standard/TryAtSoftware.Extensions.DependencyInjection.Standard.csproj
@@ -18,6 +18,10 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <InternalsVisibleTo Include="TryAtSoftware.Extensions.DependencyInjection.Standard.Tests" />
+    </ItemGroup>
+
+    <ItemGroup>
         <PackageReference Include="SonarAnalyzer.CSharp" Version="10.6.0.109712">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Pull Request Description 

This PR introduces enhancements primarily centered around enabling open generic service registration within the built-in dependency injection container.

This PR also changes the visibility of the `ServiceConfiguration.LifetimeIsSet` member to internal (it is not expected for this property to be used externally).

## Motivation and Context

The changes aim to enhance support for registering generic services as either open or closed generics, depending on what's necessary. This simplifies and expands the usability of the module for automatic registration of services, making it more flexible and capable of handling a wider variety of scenarios.

## Checklist

- [x] I have tested these changes thoroughly.
- [ ] I have added/updated relevant documentation.
- [x] My code follows the project's coding guidelines.
- [x] I have performed a self-review of my changes.
- [ ] My changes are backwards compatible.
